### PR TITLE
feat: 43992 implement SESMT policy  | feat: 43956 implement approval logs  | feat: 44002 implement read-only policy |  feat: 43662 save accept lgpd terms

### DIFF
--- a/src/main/java/br/com/mili/milibackend/fornecedor/application/dto/FornecedorGetAllOutputDto.java
+++ b/src/main/java/br/com/mili/milibackend/fornecedor/application/dto/FornecedorGetAllOutputDto.java
@@ -16,4 +16,6 @@ public class FornecedorGetAllOutputDto {
     private String celular;
     private String contato;
     private String email;
+    private Integer aceiteLgpd;
+
 }

--- a/src/main/java/br/com/mili/milibackend/fornecedor/application/dto/FornecedorGetByCodUsuarioOutputDto.java
+++ b/src/main/java/br/com/mili/milibackend/fornecedor/application/dto/FornecedorGetByCodUsuarioOutputDto.java
@@ -66,4 +66,6 @@ public class FornecedorGetByCodUsuarioOutputDto {
 
     private Integer codUsuario;
 
+    private Integer aceiteLgpd;
+
 }

--- a/src/main/java/br/com/mili/milibackend/fornecedor/application/dto/FornecedorGetByIdOutputDto.java
+++ b/src/main/java/br/com/mili/milibackend/fornecedor/application/dto/FornecedorGetByIdOutputDto.java
@@ -66,5 +66,5 @@ public class FornecedorGetByIdOutputDto {
 
     private Integer codUsuario;
 
-
+    private Integer aceiteLgpd;
 }

--- a/src/main/java/br/com/mili/milibackend/fornecedor/application/dto/FornecedorMeusDadosUpdateInputDto.java
+++ b/src/main/java/br/com/mili/milibackend/fornecedor/application/dto/FornecedorMeusDadosUpdateInputDto.java
@@ -1,7 +1,9 @@
 package br.com.mili.milibackend.fornecedor.application.dto;
 
+import jakarta.persistence.Column;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -24,4 +26,7 @@ public class FornecedorMeusDadosUpdateInputDto {
 
     @NotBlank
     private String celular;
+
+    @NotNull
+    private Integer aceiteLgpd;
 }

--- a/src/main/java/br/com/mili/milibackend/fornecedor/application/dto/FornecedorMeusDadosUpdateOutputDto.java
+++ b/src/main/java/br/com/mili/milibackend/fornecedor/application/dto/FornecedorMeusDadosUpdateOutputDto.java
@@ -67,4 +67,5 @@ public class FornecedorMeusDadosUpdateOutputDto {
 
     private Integer codUsuario;
 
+    private Integer aceiteLgpd;
 }

--- a/src/main/java/br/com/mili/milibackend/fornecedor/application/service/FornecedorService.java
+++ b/src/main/java/br/com/mili/milibackend/fornecedor/application/service/FornecedorService.java
@@ -73,7 +73,6 @@ public class FornecedorService implements IFornecedorService {
 
         typeMap.map(inputDto, fornecedorFound);
 
-
         fornecedorRepository.save(fornecedorFound);
 
         return modelMapper.map(fornecedorFound, FornecedorMeusDadosUpdateOutputDto.class);

--- a/src/main/java/br/com/mili/milibackend/fornecedor/domain/entity/Fornecedor.java
+++ b/src/main/java/br/com/mili/milibackend/fornecedor/domain/entity/Fornecedor.java
@@ -95,6 +95,9 @@ public class Fornecedor {
     @Column(name = "INSCRICAO_MUNICIPAL")
     private String inscricaoMunicipal;
 
+    @Column(name = "ACEITE_LGPD")
+    private Integer aceiteLgpd;
+
     @Column(name = "BLOQUEADO")
     private String bloqueado;
 

--- a/src/main/java/br/com/mili/milibackend/fornecedor/infra/dto/FornecedorResumoDto.java
+++ b/src/main/java/br/com/mili/milibackend/fornecedor/infra/dto/FornecedorResumoDto.java
@@ -17,4 +17,5 @@ public class FornecedorResumoDto {
     private String celular;
     private String contato;
     private String email;
+    private Integer aceiteLgpd;
 }

--- a/src/main/java/br/com/mili/milibackend/fornecedor/infra/repository/fornecedorRepository/FornecedorRepositoryImpl.java
+++ b/src/main/java/br/com/mili/milibackend/fornecedor/infra/repository/fornecedorRepository/FornecedorRepositoryImpl.java
@@ -36,7 +36,8 @@ public class FornecedorRepositoryImpl implements IFornecedorCustomRepository {
                 root.get("nomeFantasia"),
                 root.get("celular"),
                 root.get("contato"),
-                root.get("email")
+                root.get("email"),
+                root.get("aceiteLgpd")
         ));
 
         // aplica a Specification (predicados)

--- a/src/main/java/br/com/mili/milibackend/gfd/adapter/exception/GfdFuncionarioCodeException.java
+++ b/src/main/java/br/com/mili/milibackend/gfd/adapter/exception/GfdFuncionarioCodeException.java
@@ -5,7 +5,8 @@ import lombok.Getter;
 @Getter
 public enum GfdFuncionarioCodeException {
 
-    GFD_FUNCIONARIO_NAO_ENCONTRADO("GFD_FUNCIONARIO_NAO_ENCONTRADO", "O funcionário não foi encontrado");
+    GFD_FUNCIONARIO_NAO_ENCONTRADO("GFD_FUNCIONARIO_NAO_ENCONTRADO", "O funcionário não foi encontrado"),
+    GFD_FUNCIONARIO_LIBERACAO_COM_DOCUMENTO_PENDENTE("GFD_FUNCIONARIO_LIBERACAO_COM_DOCUMENTO_PENDENTE", "Existes documentos pendentes, caso deseje liberar o funcionário, informe a justificativa");
 
     private final String code;
     private final String mensagem;

--- a/src/main/java/br/com/mili/milibackend/gfd/adapter/web/controller/GfdMController.java
+++ b/src/main/java/br/com/mili/milibackend/gfd/adapter/web/controller/GfdMController.java
@@ -1,31 +1,30 @@
 package br.com.mili.milibackend.gfd.adapter.web.controller;
 
 
-import br.com.mili.milibackend.gfd.application.dto.GfdMDocumentosGetAllInputDto;
-import br.com.mili.milibackend.gfd.application.dto.*;
+import br.com.mili.milibackend.gfd.application.dto.GfdMFornecedorGetInputDto;
+import br.com.mili.milibackend.gfd.application.dto.GfdMFornecedorGetOutputDto;
+import br.com.mili.milibackend.gfd.application.dto.GfdMVerificarFornecedorInputDto;
+import br.com.mili.milibackend.gfd.application.dto.GfdMVerificarFornecedorOutputDto;
 import br.com.mili.milibackend.gfd.application.policy.IGfdPolicy;
 import br.com.mili.milibackend.gfd.domain.interfaces.IGfdManagerService;
 import br.com.mili.milibackend.shared.infra.security.model.CustomUserPrincipal;
-import jakarta.transaction.Transactional;
-import jakarta.validation.Valid;
 import lombok.extern.slf4j.Slf4j;
-import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.Set;
-import java.util.stream.Collectors;
-
-import static br.com.mili.milibackend.shared.roles.GfdRolesConstants.ROLE_ANALISTA;
-import static br.com.mili.milibackend.shared.roles.GfdRolesConstants.ROLE_FORNECEDOR;
+import static br.com.mili.milibackend.shared.roles.GfdRolesConstants.*;
 
 
 @Slf4j
 @RestController
 @RequestMapping(GfdMController.ENDPOINT)
+@PreAuthorize("hasAuthority('" + ROLE_ANALISTA + "') " +
+              "or hasAuthority('" + ROLE_FORNECEDOR + "')" +
+              "or hasAuthority('" + ROLE_VISUALIZACAO + "')" +
+              "or hasAuthority('" + ROLE_SESMT + "')"
+)
 public class GfdMController {
     protected static final String ENDPOINT = "/mili-backend/v1/gfd";
 
@@ -37,7 +36,6 @@ public class GfdMController {
         this.gfdPolicy = gfdPolicy;
     }
 
-    @PreAuthorize("hasAuthority('" + ROLE_ANALISTA + "') or hasAuthority('" + ROLE_FORNECEDOR + "')")
     @GetMapping("verificar-fornecedor")
     public ResponseEntity<GfdMVerificarFornecedorOutputDto> verificarFornecedor(
             @AuthenticationPrincipal CustomUserPrincipal user,
@@ -48,15 +46,13 @@ public class GfdMController {
         var inputDto = new GfdMVerificarFornecedorInputDto();
         inputDto.setCodUsuario(user.getIdUser());
 
-        if (gfdPolicy.isAnalista(user)) {
+        if (!gfdPolicy.isFornecedor(user)) {
             inputDto.setId(fornecedorId);
         }
 
         return ResponseEntity.ok(gfdManagerService.verifyFornecedor(inputDto));
     }
 
-
-    @PreAuthorize("hasAuthority('" + ROLE_ANALISTA + "') or hasAuthority('" + ROLE_FORNECEDOR + "')")
     @GetMapping("fornecedores")
     public ResponseEntity<GfdMFornecedorGetOutputDto> recuperarFornecedor(
             @AuthenticationPrincipal CustomUserPrincipal user,
@@ -67,7 +63,7 @@ public class GfdMController {
         var inputDto = new GfdMFornecedorGetInputDto();
         inputDto.setCodUsuario(user.getIdUser());
 
-        if (gfdPolicy.isAnalista(user)) {
+        if (!gfdPolicy.isFornecedor(user)) {
             inputDto.setId(fornecedorId);
         }
 

--- a/src/main/java/br/com/mili/milibackend/gfd/adapter/web/controller/GfdMFuncionarioController.java
+++ b/src/main/java/br/com/mili/milibackend/gfd/adapter/web/controller/GfdMFuncionarioController.java
@@ -2,45 +2,51 @@ package br.com.mili.milibackend.gfd.adapter.web.controller;
 
 
 import br.com.mili.milibackend.gfd.application.dto.*;
+import br.com.mili.milibackend.gfd.application.dto.gfdFuncionario.GfdFuncionarioLiberarInputDto;
+import br.com.mili.milibackend.gfd.application.dto.gfdFuncionario.GfdFuncionarioLiberarOutputDto;
+import br.com.mili.milibackend.gfd.application.dto.gfdFuncionario.GfdFuncionarioUpdateObservacaoInputDto;
+import br.com.mili.milibackend.gfd.application.dto.gfdFuncionario.GfdFuncionarioUpdateObservacaoOutputDto;
 import br.com.mili.milibackend.gfd.application.policy.IGfdPolicy;
 import br.com.mili.milibackend.gfd.domain.interfaces.IGfdManagerService;
+import br.com.mili.milibackend.gfd.domain.usecases.LiberarFuncionarioUseCase;
+import br.com.mili.milibackend.gfd.domain.usecases.UpdateObservacaoFuncionarioUseCase;
 import br.com.mili.milibackend.shared.infra.security.model.CustomUserPrincipal;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.transaction.Transactional;
 import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.Set;
-import java.util.stream.Collectors;
-
-import static br.com.mili.milibackend.shared.roles.GfdRolesConstants.ROLE_ANALISTA;
-import static br.com.mili.milibackend.shared.roles.GfdRolesConstants.ROLE_FORNECEDOR;
+import static br.com.mili.milibackend.shared.roles.GfdRolesConstants.*;
 
 
 @Slf4j
 @RestController
 @RequestMapping(GfdMFuncionarioController.ENDPOINT)
+@Tag(name = "GFD - Funcionário", description = "Rotas para manipulação de Funcionários")
+@RequiredArgsConstructor
 public class GfdMFuncionarioController {
     protected static final String ENDPOINT = "/mili-backend/v1/gfd";
 
     private final IGfdManagerService gfdManagerService;
+    private final LiberarFuncionarioUseCase updateLiberarFuncionarioUseCase;
+    private final UpdateObservacaoFuncionarioUseCase updateObservacaoFuncionarioUseCase;
     private final IGfdPolicy gfdPolicy;
-
-
-    public GfdMFuncionarioController(IGfdManagerService gfdManagerService, IGfdPolicy gfdPolicy) {
-        this.gfdManagerService = gfdManagerService;
-        this.gfdPolicy = gfdPolicy;
-    }
 
 
     @PreAuthorize("hasAuthority('" + ROLE_ANALISTA + "') or hasAuthority('" + ROLE_FORNECEDOR + "')")
     @PostMapping("funcionarios")
     @Transactional
+    @Operation(
+            summary = "Cria um novo funcionário",
+            description = "Retorna o funcionário criado, sendo que se o usuário for fornecedor, o funcionário criado será de seu usuário(empresa)"
+    )
     public ResponseEntity<GfdMFuncionarioCreateOutputDto> createFuncionario(
             @AuthenticationPrincipal CustomUserPrincipal user,
             @RequestBody @Valid GfdMFuncionarioCreateInputDto inputDto
@@ -54,9 +60,17 @@ public class GfdMFuncionarioController {
         return ResponseEntity.ok(gfdManagerService.createFuncionario(inputDto));
     }
 
+    //todo criar controller de atualizar apenas observação
+
+
+
     @PreAuthorize("hasAuthority('" + ROLE_ANALISTA + "') or hasAuthority('" + ROLE_FORNECEDOR + "')")
     @PutMapping("funcionarios/{id}")
     @Transactional
+    @Operation(
+            summary = "Atualiza um funcionário",
+            description = "Retorna o funcionário, sendo que se o usuário for fornecedor, o funcionário atualizado será de seu usuário(empresa)"
+    )
     public ResponseEntity<GfdMFuncionarioUpdateOutputDto> updateFuncionario(
             @AuthenticationPrincipal CustomUserPrincipal user,
             @PathVariable Integer id,
@@ -73,9 +87,16 @@ public class GfdMFuncionarioController {
         return ResponseEntity.ok(gfdManagerService.updateFuncionario(inputDto));
     }
 
-    @PreAuthorize("hasAuthority('" + ROLE_ANALISTA + "') or hasAuthority('" + ROLE_FORNECEDOR + "')")
+    @PreAuthorize("hasAuthority('" + ROLE_ANALISTA + "') " +
+                  "or hasAuthority('" + ROLE_FORNECEDOR + "')" +
+                  "or hasAuthority('" + ROLE_VISUALIZACAO + "')" +
+                  "or hasAuthority('" + ROLE_SESMT + "')"
+    )
     @GetMapping("funcionarios/{id}")
-    @Transactional
+    @Operation(
+            summary = "Retorna um funcionário",
+            description = "Retorna o funcionário, sendo que se o usuário for fornecedor, sera retornado o funcionário de seu usuário(empresa)"
+    )
     public ResponseEntity<GfdMFuncionarioGetOutputDto> getFuncionario(
             @AuthenticationPrincipal CustomUserPrincipal user,
             @PathVariable Integer id,
@@ -95,6 +116,10 @@ public class GfdMFuncionarioController {
     @PreAuthorize("hasAuthority('" + ROLE_ANALISTA + "') or hasAuthority('" + ROLE_FORNECEDOR + "')")
     @DeleteMapping("funcionarios/{id}")
     @Transactional
+    @Operation(
+            summary = "Deleta um funcionário",
+            description = "Não retorna nada, sendo que se o usuário for fornecedor, o funcionário deletado será de seu usuário(empresa)"
+    )
     public ResponseEntity<Void> deleteFuncionario(
             @AuthenticationPrincipal CustomUserPrincipal user,
             @PathVariable Integer id,
@@ -113,8 +138,60 @@ public class GfdMFuncionarioController {
         return ResponseEntity.noContent().build();
     }
 
-    @PreAuthorize("hasAuthority('" + ROLE_ANALISTA + "') or hasAuthority('" + ROLE_FORNECEDOR + "')")
+
+    @PreAuthorize("hasAuthority('" + ROLE_ANALISTA + "') " +
+                  "or hasAuthority('" + ROLE_SESMT + "')"
+    )
+    @PutMapping("funcionarios/{id}/observacao")
+    @Transactional
+    @Operation(
+            summary = "Atualiza a observação de um funcionário",
+            description = "Retorna o funcionário. Faz a liberação do funcionário, caso o usuario tenha " +
+                          "algum documento pendente a justificativa se torna obrigatório"
+    )
+    public ResponseEntity<GfdFuncionarioUpdateObservacaoOutputDto> updateObservacao(
+            @AuthenticationPrincipal CustomUserPrincipal user,
+            @PathVariable Integer id,
+            @RequestBody @Valid GfdFuncionarioUpdateObservacaoInputDto inputDto
+    ) {
+        log.info("{} {}/{}", RequestMethod.PUT, ENDPOINT, user.getUsername());
+        inputDto.setId(id);
+
+        return ResponseEntity.ok(updateObservacaoFuncionarioUseCase.execute(inputDto));
+    }
+
+    @PreAuthorize("hasAuthority('" + ROLE_ANALISTA + "') " +
+                  "or hasAuthority('" + ROLE_SESMT + "')"
+    )
+    @PutMapping("funcionarios/{id}/liberar")
+    @Transactional
+    @Operation(
+            summary = "Atualiza o status de liberação de um funcionário",
+            description = "Retorna o funcionário. Faz a liberação do funcionário, caso o usuario tenha " +
+                          "algum documento pendente a justificativa se torna obrigatório"
+    )
+    public ResponseEntity<GfdFuncionarioLiberarOutputDto> liberar(
+            @AuthenticationPrincipal CustomUserPrincipal user,
+            @PathVariable Integer id,
+            @RequestBody @Valid GfdFuncionarioLiberarInputDto inputDto
+    ) {
+        log.info("{} {}/{}", RequestMethod.PUT, ENDPOINT, user.getUsername());
+        inputDto.setId(id);
+        inputDto.setUsuario(user.getIdUser());
+
+        return ResponseEntity.ok(updateLiberarFuncionarioUseCase.execute(inputDto));
+    }
+
+    @PreAuthorize("hasAuthority('" + ROLE_ANALISTA + "') " +
+                  "or hasAuthority('" + ROLE_FORNECEDOR + "')" +
+                  "or hasAuthority('" + ROLE_VISUALIZACAO + "')" +
+                  "or hasAuthority('" + ROLE_SESMT + "')"
+    )
     @GetMapping("funcionarios")
+    @Operation(
+            summary = "Retorna todos os funcionários",
+            description = "Retorna todos os funcionários, sendo que se o usuário for fornecedor, sera retornado os funcionários de seu usuário(empresa)"
+    )
     public ResponseEntity<GfdMFuncionarioGetAllOutputDto> getAllFuncionario(
             @AuthenticationPrincipal CustomUserPrincipal user,
             @ParameterObject @ModelAttribute @Valid GfdMFuncionarioGetAllInputDto inputDto

--- a/src/main/java/br/com/mili/milibackend/gfd/adapter/web/controller/GfdMFuncionarioController.java
+++ b/src/main/java/br/com/mili/milibackend/gfd/adapter/web/controller/GfdMFuncionarioController.java
@@ -60,9 +60,6 @@ public class GfdMFuncionarioController {
         return ResponseEntity.ok(gfdManagerService.createFuncionario(inputDto));
     }
 
-    //todo criar controller de atualizar apenas observação
-
-
 
     @PreAuthorize("hasAuthority('" + ROLE_ANALISTA + "') or hasAuthority('" + ROLE_FORNECEDOR + "')")
     @PutMapping("funcionarios/{id}")

--- a/src/main/java/br/com/mili/milibackend/gfd/adapter/web/controller/GfdTipoDocumentoController.java
+++ b/src/main/java/br/com/mili/milibackend/gfd/adapter/web/controller/GfdTipoDocumentoController.java
@@ -15,7 +15,7 @@ import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
-import static br.com.mili.milibackend.shared.roles.GfdRolesConstants.ROLE_ANALISTA;
+import static br.com.mili.milibackend.shared.roles.GfdRolesConstants.*;
 
 
 @Slf4j
@@ -27,7 +27,11 @@ public class GfdTipoDocumentoController {
 
     private final IGfdTipoDocumentoService gfdTipoDocumentoService;
 
-    @PreAuthorize("hasAuthority('" + ROLE_ANALISTA + "')")
+       @PreAuthorize("hasAuthority('" + ROLE_ANALISTA + "') " +
+                  "or hasAuthority('" + ROLE_FORNECEDOR + "')" +
+                  "or hasAuthority('" + ROLE_VISUALIZACAO + "')" +
+                  "or hasAuthority('" + ROLE_SESMT + "')"
+    )
     @GetMapping()
     public ResponseEntity<List<GfdTipoDocumentoGetAllOutputDto>> getAll(
             @AuthenticationPrincipal CustomUserPrincipal user,
@@ -38,7 +42,11 @@ public class GfdTipoDocumentoController {
         return ResponseEntity.ok(gfdTipoDocumentoService.getAll(inputDto));
     }
 
-    @PreAuthorize("hasAuthority('" + ROLE_ANALISTA + "')")
+       @PreAuthorize("hasAuthority('" + ROLE_ANALISTA + "') " +
+                  "or hasAuthority('" + ROLE_FORNECEDOR + "')" +
+                  "or hasAuthority('" + ROLE_VISUALIZACAO + "')" +
+                  "or hasAuthority('" + ROLE_SESMT + "')"
+    )
     @GetMapping("{id}")
     public ResponseEntity<GfdTipoDocumentoGetByIdOutputDto> getById(
             @AuthenticationPrincipal CustomUserPrincipal user,

--- a/src/main/java/br/com/mili/milibackend/gfd/application/dto/GfdMFornecedorGetOutputDto.java
+++ b/src/main/java/br/com/mili/milibackend/gfd/application/dto/GfdMFornecedorGetOutputDto.java
@@ -65,4 +65,6 @@ public class GfdMFornecedorGetOutputDto {
     private String bloqueado;
 
     private Integer codUsuario;
+
+    private Integer aceiteLgpd;
 }

--- a/src/main/java/br/com/mili/milibackend/gfd/application/dto/GfdMFuncionarioGetOutputDto.java
+++ b/src/main/java/br/com/mili/milibackend/gfd/application/dto/GfdMFuncionarioGetOutputDto.java
@@ -32,6 +32,12 @@ public class GfdMFuncionarioGetOutputDto {
         private Integer liberado;
         private FornecedorDto fornecedor;
 
+        private Integer totalEnviado;
+        private Integer totalConforme;
+        private Integer totalNaoConforme;
+        private Integer totalEmAnalise;
+        private Integer naoEnviado;
+
         @AllArgsConstructor
         @NoArgsConstructor
         @Getter

--- a/src/main/java/br/com/mili/milibackend/gfd/application/dto/GfdMFuncionarioUpdateInputDto.java
+++ b/src/main/java/br/com/mili/milibackend/gfd/application/dto/GfdMFuncionarioUpdateInputDto.java
@@ -30,7 +30,6 @@ public class GfdMFuncionarioUpdateInputDto {
         private LocalDate periodoInicial;
         private LocalDate periodoFinal;
         private String observacao;
-        private Integer liberado;
 
 
         @AllArgsConstructor

--- a/src/main/java/br/com/mili/milibackend/gfd/application/dto/gfdDocumento/GfdDocumentoUpdateStatusObservacaoInputDto.java
+++ b/src/main/java/br/com/mili/milibackend/gfd/application/dto/gfdDocumento/GfdDocumentoUpdateStatusObservacaoInputDto.java
@@ -1,0 +1,21 @@
+package br.com.mili.milibackend.gfd.application.dto.gfdDocumento;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Setter
+public class GfdDocumentoUpdateStatusObservacaoInputDto {
+    @NotNull
+    private Integer id;
+
+    @NotNull
+    private String status;
+
+    private String observacao;
+}

--- a/src/main/java/br/com/mili/milibackend/gfd/application/dto/gfdDocumento/GfdDocumentoUpdateStatusObservacaoOutputDto.java
+++ b/src/main/java/br/com/mili/milibackend/gfd/application/dto/gfdDocumento/GfdDocumentoUpdateStatusObservacaoOutputDto.java
@@ -1,0 +1,51 @@
+package br.com.mili.milibackend.gfd.application.dto.gfdDocumento;
+
+import br.com.mili.milibackend.gfd.domain.entity.GfdDocumentoStatusEnum;
+import lombok.*;
+
+import java.time.LocalDate;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Setter
+@Builder
+public class GfdDocumentoUpdateStatusObservacaoOutputDto {
+    private Integer id;
+    private Integer ctforCodigo;
+    private String tipoDocumento;
+    private String nomeArquivo;
+    private String nomeArquivoPath;
+    private Integer tamanhoArquivo;
+    private LocalDate dataEmissao;
+    private LocalDate dataCadastro;
+    private LocalDate dataValidade;
+    private String tipoArquivo;
+    private String observacao;
+    private GfdDocumentoStatusEnum status;
+    private GfdDocumentoGetAllOutputDto.GfdTipoDocumentoDto gfdTipoDocumento;
+    private GfdDocumentoGetAllOutputDto.FuncionarioDto funcionario;
+
+
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Getter
+    @Setter
+    @Builder
+    public static class GfdTipoDocumentoDto {
+        private Integer id;
+        private String nome;
+        private Integer diasValidade;
+    }
+
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Getter
+    @Setter
+    @Builder
+    public static class FuncionarioDto {
+        private Integer id;
+        private String nome;
+        private String cpf;
+    }
+}

--- a/src/main/java/br/com/mili/milibackend/gfd/application/dto/gfdFuncionario/GfdFuncionarioLiberarInputDto.java
+++ b/src/main/java/br/com/mili/milibackend/gfd/application/dto/gfdFuncionario/GfdFuncionarioLiberarInputDto.java
@@ -1,0 +1,23 @@
+package br.com.mili.milibackend.gfd.application.dto.gfdFuncionario;
+
+
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import lombok.*;
+
+@Getter
+@AllArgsConstructor
+@Setter
+@EqualsAndHashCode
+@NoArgsConstructor
+public class GfdFuncionarioLiberarInputDto {
+    @NotNull
+    private Integer id;
+
+    @NotNull
+    private Integer liberado;
+
+    private Integer usuario;
+
+    private String justificativa;
+}

--- a/src/main/java/br/com/mili/milibackend/gfd/application/dto/gfdFuncionario/GfdFuncionarioLiberarOutputDto.java
+++ b/src/main/java/br/com/mili/milibackend/gfd/application/dto/gfdFuncionario/GfdFuncionarioLiberarOutputDto.java
@@ -9,18 +9,16 @@ import java.time.LocalDate;
 @Setter
 @EqualsAndHashCode
 @NoArgsConstructor
-public class GfdFuncionarioUpdateInputDto {
+public class GfdFuncionarioLiberarOutputDto {
     private Integer id;
-    private FornecedorDto fornecedor;
     private String nome;
-    private String cpf;
-    private LocalDate dataNascimento;
-    private String paisNacionalidade;
     private String funcao;
     private String tipoContratacao;
-    private LocalDate periodoInicial;
-    private LocalDate periodoFinal;
-    private String observacao;
+    private LocalDate periodoInicio;
+    private LocalDate periodoFim;
+    private Integer ativo;
+
+    private GfdFuncionarioGetAllInputDto.FornecedorDto fornecedor;
 
     @AllArgsConstructor
     @NoArgsConstructor
@@ -28,5 +26,6 @@ public class GfdFuncionarioUpdateInputDto {
     @Setter
     public static class FornecedorDto {
         private Integer codigo;
+
     }
 }

--- a/src/main/java/br/com/mili/milibackend/gfd/application/dto/gfdFuncionario/GfdFuncionarioUpdateObservacaoInputDto.java
+++ b/src/main/java/br/com/mili/milibackend/gfd/application/dto/gfdFuncionario/GfdFuncionarioUpdateObservacaoInputDto.java
@@ -1,0 +1,19 @@
+package br.com.mili.milibackend.gfd.application.dto.gfdFuncionario;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Setter
+public class GfdFuncionarioUpdateObservacaoInputDto {
+    @NotNull
+    private Integer id;
+
+    @NotNull
+    private String observacao;
+}

--- a/src/main/java/br/com/mili/milibackend/gfd/application/dto/gfdFuncionario/GfdFuncionarioUpdateObservacaoOutputDto.java
+++ b/src/main/java/br/com/mili/milibackend/gfd/application/dto/gfdFuncionario/GfdFuncionarioUpdateObservacaoOutputDto.java
@@ -1,15 +1,17 @@
 package br.com.mili.milibackend.gfd.application.dto.gfdFuncionario;
 
-import lombok.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 import java.time.LocalDate;
 
-@Getter
 @AllArgsConstructor
-@Setter
-@EqualsAndHashCode
 @NoArgsConstructor
-public class GfdFuncionarioUpdateInputDto {
+@Getter
+@Setter
+public class GfdFuncionarioUpdateObservacaoOutputDto {
     private Integer id;
     private FornecedorDto fornecedor;
     private String nome;

--- a/src/main/java/br/com/mili/milibackend/gfd/application/policy/GfdPolicy.java
+++ b/src/main/java/br/com/mili/milibackend/gfd/application/policy/GfdPolicy.java
@@ -7,14 +7,13 @@ import org.springframework.stereotype.Component;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import static br.com.mili.milibackend.shared.roles.GfdRolesConstants.ROLE_ANALISTA;
-import static br.com.mili.milibackend.shared.roles.GfdRolesConstants.ROLE_FORNECEDOR;
+import static br.com.mili.milibackend.shared.roles.GfdRolesConstants.*;
 
 @Component
 public class GfdPolicy implements IGfdPolicy {
 
     public boolean isAnalista(CustomUserPrincipal user) {
-        return hasRole(user, ROLE_ANALISTA);
+        return hasRole(user, ROLE_ANALISTA) || hasRole(user, ROLE_SESMT) || hasRole(user, ROLE_VISUALIZACAO);
     }
 
     public boolean isFornecedor(CustomUserPrincipal user) {

--- a/src/main/java/br/com/mili/milibackend/gfd/application/service/GfdFuncionarioService.java
+++ b/src/main/java/br/com/mili/milibackend/gfd/application/service/GfdFuncionarioService.java
@@ -5,12 +5,8 @@ import br.com.mili.milibackend.gfd.domain.entity.GfdFuncionario;
 import br.com.mili.milibackend.gfd.domain.interfaces.IGfdFuncionarioService;
 import br.com.mili.milibackend.gfd.infra.repository.gfdFuncionario.GfdFuncionarioRepository;
 import br.com.mili.milibackend.shared.exception.types.NotFoundException;
-import br.com.mili.milibackend.shared.page.pagination.MyPage;
-import br.com.mili.milibackend.shared.page.pagination.PageBaseImpl;
 import org.modelmapper.ModelMapper;
 import org.springframework.stereotype.Service;
-
-import java.util.List;
 
 import static br.com.mili.milibackend.gfd.adapter.exception.GfdFuncionarioCodeException.GFD_FUNCIONARIO_NAO_ENCONTRADO;
 
@@ -22,54 +18,6 @@ public class GfdFuncionarioService implements IGfdFuncionarioService {
     public GfdFuncionarioService(GfdFuncionarioRepository gfdFuncionarioRepository, ModelMapper modelMapper) {
         this.gfdFuncionarioRepository = gfdFuncionarioRepository;
         this.modelMapper = modelMapper;
-    }
-
-    @Override
-    public MyPage<GfdFuncionarioGetAllOutputDto> getAll(GfdFuncionarioGetAllInputDto inputDto) {
-        var pageNumber = inputDto.getPageable().getPage() > 0 ? inputDto.getPageable().getPage() - 1 : 0;
-        var pageSize = inputDto.getPageable().getSize() > 0 ? inputDto.getPageable().getSize() : 20;
-
-        var nome = inputDto.getNome() != null ? "%" + inputDto.getNome() + "%" : null;
-        var funcao = inputDto.getFuncao() != null ? "%" + inputDto.getFuncao() + "%" : null;
-
-        var gfdFuncionarioStatusProjection = gfdFuncionarioRepository.getAll(
-                inputDto.getId(),
-                nome,
-                funcao,
-                inputDto.getTipoContratacao(),
-                inputDto.getPeriodoInicio(),
-                inputDto.getPeriodoFim(),
-                inputDto.getFornecedor() != null ? inputDto.getFornecedor().getCodigo() : null,
-                pageNumber,
-                pageSize,
-                inputDto.getAtivo() != null ? inputDto.getAtivo() : 1
-        );
-
-        var totalCount = gfdFuncionarioRepository.getAllCount(
-                inputDto.getId(),
-                inputDto.getNome(),
-                inputDto.getFuncao(),
-                inputDto.getTipoContratacao(),
-                inputDto.getPeriodoInicio(),
-                inputDto.getPeriodoFim(),
-                inputDto.getFornecedor() != null ? inputDto.getFornecedor().getCodigo() : null,
-                inputDto.getAtivo() != null ? inputDto.getAtivo() : 1
-        );
-
-        List<GfdFuncionarioGetAllOutputDto> gfdFuncionarioGetAllOutputDto = gfdFuncionarioStatusProjection.stream()
-                .map(gfdDocumento -> {
-                    var dto = modelMapper.map(gfdDocumento, GfdFuncionarioGetAllOutputDto.class);
-
-                    var fornecedorDto = new GfdFuncionarioGetAllOutputDto.FornecedorDto();
-                    fornecedorDto.setCodigo(gfdDocumento.getCtforCodigo());
-                    dto.setFornecedor(fornecedorDto);
-
-                    return dto;
-                })
-                .toList();
-
-        return new PageBaseImpl<>(gfdFuncionarioGetAllOutputDto, pageNumber + 1, pageSize, totalCount) {
-        };
     }
 
     @Override

--- a/src/main/java/br/com/mili/milibackend/gfd/application/usecases/GetAllGfdFuncionarioUseCaseImpl.java
+++ b/src/main/java/br/com/mili/milibackend/gfd/application/usecases/GetAllGfdFuncionarioUseCaseImpl.java
@@ -1,0 +1,70 @@
+package br.com.mili.milibackend.gfd.application.usecases;
+
+import br.com.mili.milibackend.gfd.application.dto.gfdFuncionario.GfdFuncionarioGetAllInputDto;
+import br.com.mili.milibackend.gfd.application.dto.gfdFuncionario.GfdFuncionarioGetAllOutputDto;
+import br.com.mili.milibackend.gfd.domain.usecases.GetAllGfdFuncionarioUseCase;
+import br.com.mili.milibackend.gfd.infra.repository.gfdFuncionario.GfdFuncionarioRepository;
+import br.com.mili.milibackend.shared.page.pagination.MyPage;
+import br.com.mili.milibackend.shared.page.pagination.PageBaseImpl;
+import lombok.RequiredArgsConstructor;
+import org.modelmapper.ModelMapper;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class GetAllGfdFuncionarioUseCaseImpl implements GetAllGfdFuncionarioUseCase {
+    private final GfdFuncionarioRepository gfdFuncionarioRepository;
+    private final ModelMapper modelMapper;
+
+    @Override
+    public MyPage<GfdFuncionarioGetAllOutputDto> execute(GfdFuncionarioGetAllInputDto inputDto) {
+        var pageNumber = inputDto.getPageable().getPage() > 0 ? inputDto.getPageable().getPage() - 1 : 0;
+        var pageSize = inputDto.getPageable().getSize() > 0 ? inputDto.getPageable().getSize() : 20;
+
+        var nome = inputDto.getNome() != null ? "%" + inputDto.getNome() + "%" : null;
+        var funcao = inputDto.getFuncao() != null ? "%" + inputDto.getFuncao() + "%" : null;
+
+        var gfdFuncionarioStatusProjection = gfdFuncionarioRepository.getAll(
+                inputDto.getId(),
+                nome,
+                funcao,
+                inputDto.getTipoContratacao(),
+                inputDto.getPeriodoInicio(),
+                inputDto.getPeriodoFim(),
+                inputDto.getFornecedor() != null ? inputDto.getFornecedor().getCodigo() : null,
+                pageNumber,
+                pageSize,
+                inputDto.getAtivo() != null ? inputDto.getAtivo() : 1
+        );
+
+        var totalCount = gfdFuncionarioRepository.getAllCount(
+                inputDto.getId(),
+                inputDto.getNome(),
+                inputDto.getFuncao(),
+                inputDto.getTipoContratacao(),
+                inputDto.getPeriodoInicio(),
+                inputDto.getPeriodoFim(),
+                inputDto.getFornecedor() != null ? inputDto.getFornecedor().getCodigo() : null,
+                inputDto.getAtivo() != null ? inputDto.getAtivo() : 1
+        );
+
+        List<GfdFuncionarioGetAllOutputDto> gfdFuncionarioGetAllOutputDto = gfdFuncionarioStatusProjection.stream()
+                .map(gfdDocumento -> {
+                    var dto = modelMapper.map(gfdDocumento, GfdFuncionarioGetAllOutputDto.class);
+
+                    var fornecedorDto = new GfdFuncionarioGetAllOutputDto.FornecedorDto();
+                    fornecedorDto.setCodigo(gfdDocumento.getCtforCodigo());
+                    dto.setFornecedor(fornecedorDto);
+
+                    return dto;
+                })
+                .toList();
+
+        return new PageBaseImpl<>(gfdFuncionarioGetAllOutputDto, pageNumber + 1, pageSize, totalCount) {
+        };
+    }
+
+
+}

--- a/src/main/java/br/com/mili/milibackend/gfd/application/usecases/LiberarFuncionarioUseCaseImpl.java
+++ b/src/main/java/br/com/mili/milibackend/gfd/application/usecases/LiberarFuncionarioUseCaseImpl.java
@@ -1,0 +1,68 @@
+package br.com.mili.milibackend.gfd.application.usecases;
+
+import br.com.mili.milibackend.gfd.adapter.exception.GfdFuncionarioCodeException;
+import br.com.mili.milibackend.gfd.application.dto.gfdFuncionario.GfdFuncionarioLiberarInputDto;
+import br.com.mili.milibackend.gfd.application.dto.gfdFuncionario.GfdFuncionarioLiberarOutputDto;
+import br.com.mili.milibackend.gfd.domain.entity.GfdFuncionarioLiberacao;
+import br.com.mili.milibackend.gfd.domain.usecases.GetAllGfdFuncionarioUseCase;
+import br.com.mili.milibackend.gfd.domain.usecases.LiberarFuncionarioUseCase;
+import br.com.mili.milibackend.gfd.infra.repository.gfdFuncionario.GfdFuncionarioLiberacaoRepository;
+import br.com.mili.milibackend.gfd.infra.repository.gfdFuncionario.GfdFuncionarioRepository;
+import br.com.mili.milibackend.shared.exception.types.NotFoundException;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.modelmapper.ModelMapper;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+
+@Service
+@RequiredArgsConstructor
+public class LiberarFuncionarioUseCaseImpl implements LiberarFuncionarioUseCase {
+    private final GfdFuncionarioRepository gfdFuncionarioRepository;
+    private final GfdFuncionarioLiberacaoRepository gfdFuncionarioLiberacaoRepository;
+    private final GetAllGfdFuncionarioUseCase getAllGfdFuncionarioUseCase;
+    private final ModelMapper modelMapper;
+
+    @Override
+    @Transactional
+    public GfdFuncionarioLiberarOutputDto execute(GfdFuncionarioLiberarInputDto inputDto) {
+        var gfdFuncionarioFound = gfdFuncionarioRepository.findById(inputDto.getId()).orElseThrow(() -> new NotFoundException(
+                GfdFuncionarioCodeException.GFD_FUNCIONARIO_NAO_ENCONTRADO.getMensagem(),
+                GfdFuncionarioCodeException.GFD_FUNCIONARIO_NAO_ENCONTRADO.getCode()));
+
+        // verifica se o funcionario tem algum algum documento pendente
+        // caso afirmativo, é obrigado a enviar a justificativa
+        var documents = gfdFuncionarioRepository.getAllDocuments(inputDto.getId());
+
+        var documentosPendentes = documents.getTotalEnviado() > 0 ||
+                                  documents.getTotalNaoConforme() > 0 ||
+                                  documents.getTotalEmAnalise() > 0 ||
+                                  documents.getNaoEnviado() > 0;
+
+        var funcionarioNaoLiberado = gfdFuncionarioFound.getLiberado() == 0;
+
+        if (documentosPendentes && funcionarioNaoLiberado) {
+            if (inputDto.getJustificativa() == null || inputDto.getJustificativa().isEmpty()) {
+                throw new NotFoundException(
+                        GfdFuncionarioCodeException.GFD_FUNCIONARIO_LIBERACAO_COM_DOCUMENTO_PENDENTE.getMensagem(),
+                        GfdFuncionarioCodeException.GFD_FUNCIONARIO_LIBERACAO_COM_DOCUMENTO_PENDENTE.getCode());
+            }
+        }
+
+        gfdFuncionarioFound.setLiberado(inputDto.getLiberado());
+
+        // salva log desse liberação
+        var gfdFuncionarioLiberacao = GfdFuncionarioLiberacao.builder()
+                .funcionario(gfdFuncionarioFound)
+                .data(LocalDateTime.now())
+                .statusLiberado(inputDto.getLiberado())
+                .justificativa(inputDto.getJustificativa())
+                .usuario(inputDto.getUsuario())
+                .build();
+
+        gfdFuncionarioLiberacaoRepository.save(gfdFuncionarioLiberacao);
+
+        return modelMapper.map(gfdFuncionarioRepository.save(gfdFuncionarioFound), GfdFuncionarioLiberarOutputDto.class);
+    }
+}

--- a/src/main/java/br/com/mili/milibackend/gfd/application/usecases/UpdateObservacaoFuncionarioUseCaseImpl.java
+++ b/src/main/java/br/com/mili/milibackend/gfd/application/usecases/UpdateObservacaoFuncionarioUseCaseImpl.java
@@ -1,0 +1,31 @@
+package br.com.mili.milibackend.gfd.application.usecases;
+
+import br.com.mili.milibackend.gfd.adapter.exception.GfdFuncionarioCodeException;
+import br.com.mili.milibackend.gfd.application.dto.gfdFuncionario.GfdFuncionarioUpdateObservacaoInputDto;
+import br.com.mili.milibackend.gfd.application.dto.gfdFuncionario.GfdFuncionarioUpdateObservacaoOutputDto;
+import br.com.mili.milibackend.gfd.domain.usecases.UpdateObservacaoFuncionarioUseCase;
+import br.com.mili.milibackend.gfd.infra.repository.gfdFuncionario.GfdFuncionarioRepository;
+import br.com.mili.milibackend.shared.exception.types.NotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.modelmapper.ModelMapper;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UpdateObservacaoFuncionarioUseCaseImpl implements UpdateObservacaoFuncionarioUseCase {
+    private final GfdFuncionarioRepository gfdFuncionarioRepository;
+    private final ModelMapper modelMapper;
+
+    @Override
+    public GfdFuncionarioUpdateObservacaoOutputDto execute(GfdFuncionarioUpdateObservacaoInputDto inputDto) {
+        var gfdFuncionarioFound = gfdFuncionarioRepository.findById(inputDto.getId()).orElseThrow(() -> new NotFoundException(
+                GfdFuncionarioCodeException.GFD_FUNCIONARIO_NAO_ENCONTRADO.getMensagem(),
+                GfdFuncionarioCodeException.GFD_FUNCIONARIO_NAO_ENCONTRADO.getCode()));
+
+        gfdFuncionarioFound.setObservacao(inputDto.getObservacao());
+
+        gfdFuncionarioRepository.save(gfdFuncionarioFound);
+
+        return modelMapper.map(gfdFuncionarioFound, GfdFuncionarioUpdateObservacaoOutputDto.class);
+    }
+}

--- a/src/main/java/br/com/mili/milibackend/gfd/application/usecases/UpdateStatusObservacaoDocumentoUseCaseImpl.java
+++ b/src/main/java/br/com/mili/milibackend/gfd/application/usecases/UpdateStatusObservacaoDocumentoUseCaseImpl.java
@@ -1,0 +1,28 @@
+package br.com.mili.milibackend.gfd.application.usecases;
+
+import br.com.mili.milibackend.gfd.adapter.exception.GfdDocumentoCodeException;
+import br.com.mili.milibackend.gfd.application.dto.gfdDocumento.GfdDocumentoUpdateStatusObservacaoInputDto;
+import br.com.mili.milibackend.gfd.application.dto.gfdDocumento.GfdDocumentoUpdateStatusObservacaoOutputDto;
+import br.com.mili.milibackend.gfd.domain.entity.GfdDocumentoStatusEnum;
+import br.com.mili.milibackend.gfd.domain.usecases.UpdateStatusObservacaoDocumentoUseCase;
+import br.com.mili.milibackend.gfd.infra.repository.gfdDocumento.GfdDocumentoRepository;
+import br.com.mili.milibackend.shared.exception.types.NotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.modelmapper.ModelMapper;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UpdateStatusObservacaoDocumentoUseCaseImpl implements UpdateStatusObservacaoDocumentoUseCase {
+    private final GfdDocumentoRepository gfdDocumentoRepository;
+    private final ModelMapper modelMapper;
+
+    public GfdDocumentoUpdateStatusObservacaoOutputDto execute(GfdDocumentoUpdateStatusObservacaoInputDto inputDto) {
+        var gfdDocumentoFound = gfdDocumentoRepository.findById(inputDto.getId()).orElseThrow(() -> new NotFoundException(GfdDocumentoCodeException.GFD_DOCUMENTO_NAO_ENCONTRADO.getMensagem(), GfdDocumentoCodeException.GFD_DOCUMENTO_NAO_ENCONTRADO.getCode()));
+
+        gfdDocumentoFound.setStatus(GfdDocumentoStatusEnum.valueOf(inputDto.getStatus()));
+        gfdDocumentoFound.setObservacao(inputDto.getObservacao());
+
+        return modelMapper.map(gfdDocumentoRepository.save(gfdDocumentoFound), GfdDocumentoUpdateStatusObservacaoOutputDto.class);
+    }
+}

--- a/src/main/java/br/com/mili/milibackend/gfd/domain/entity/GfdFuncionarioLiberacao.java
+++ b/src/main/java/br/com/mili/milibackend/gfd/domain/entity/GfdFuncionarioLiberacao.java
@@ -1,0 +1,36 @@
+package br.com.mili.milibackend.gfd.domain.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "GFD_FUNC_LIBERACAO")
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class GfdFuncionarioLiberacao {
+    @Id
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "SEQ_GFD_FUNCIONARIO_LIBERACAO")
+    @SequenceGenerator(name = "SEQ_GFD_FUNCIONARIO_LIBERACAO", sequenceName = "SEQ_GFD_FUNCIONARIO_LIBERACAO", allocationSize = 1)
+    private Integer id;
+
+    @ManyToOne
+    @JoinColumn(name = "ID_FUNCIONARIO")
+    private GfdFuncionario funcionario;
+
+    @Column(name = "CTUSU_CODIGO")
+    private Integer usuario;
+
+    @Column(name = "DATA")
+    private LocalDateTime data;
+
+    @Column(name = "STATUS_LIBERADO")
+    private Integer statusLiberado;
+
+    @Column(name = "JUSTIFICATIVA")
+    private String justificativa;
+}

--- a/src/main/java/br/com/mili/milibackend/gfd/domain/interfaces/IGfdFuncionarioService.java
+++ b/src/main/java/br/com/mili/milibackend/gfd/domain/interfaces/IGfdFuncionarioService.java
@@ -1,10 +1,8 @@
 package br.com.mili.milibackend.gfd.domain.interfaces;
 
 import br.com.mili.milibackend.gfd.application.dto.gfdFuncionario.*;
-import br.com.mili.milibackend.shared.page.pagination.MyPage;
 
 public interface IGfdFuncionarioService {
-    MyPage<GfdFuncionarioGetAllOutputDto> getAll(GfdFuncionarioGetAllInputDto inputDto);
     GfdFuncionarioCreateOutputDto create(GfdFuncionarioCreateInputDto inputDto);
     GfdFuncionarioUpdateOutputDto update(GfdFuncionarioUpdateInputDto inputDto);
     GfdFuncionarioGetByIdOutputDto getById(Integer id);

--- a/src/main/java/br/com/mili/milibackend/gfd/domain/usecases/GetAllGfdFuncionarioUseCase.java
+++ b/src/main/java/br/com/mili/milibackend/gfd/domain/usecases/GetAllGfdFuncionarioUseCase.java
@@ -1,0 +1,10 @@
+package br.com.mili.milibackend.gfd.domain.usecases;
+
+
+import br.com.mili.milibackend.gfd.application.dto.gfdFuncionario.GfdFuncionarioGetAllInputDto;
+import br.com.mili.milibackend.gfd.application.dto.gfdFuncionario.GfdFuncionarioGetAllOutputDto;
+import br.com.mili.milibackend.shared.page.pagination.MyPage;
+
+public interface GetAllGfdFuncionarioUseCase {
+    MyPage<GfdFuncionarioGetAllOutputDto> execute(GfdFuncionarioGetAllInputDto inputDto);
+}

--- a/src/main/java/br/com/mili/milibackend/gfd/domain/usecases/LiberarFuncionarioUseCase.java
+++ b/src/main/java/br/com/mili/milibackend/gfd/domain/usecases/LiberarFuncionarioUseCase.java
@@ -1,0 +1,8 @@
+package br.com.mili.milibackend.gfd.domain.usecases;
+
+import br.com.mili.milibackend.gfd.application.dto.gfdFuncionario.GfdFuncionarioLiberarInputDto;
+import br.com.mili.milibackend.gfd.application.dto.gfdFuncionario.GfdFuncionarioLiberarOutputDto;
+
+public interface LiberarFuncionarioUseCase {
+    GfdFuncionarioLiberarOutputDto execute(GfdFuncionarioLiberarInputDto inputDto);
+}

--- a/src/main/java/br/com/mili/milibackend/gfd/domain/usecases/UpdateObservacaoFuncionarioUseCase.java
+++ b/src/main/java/br/com/mili/milibackend/gfd/domain/usecases/UpdateObservacaoFuncionarioUseCase.java
@@ -1,0 +1,8 @@
+package br.com.mili.milibackend.gfd.domain.usecases;
+
+import br.com.mili.milibackend.gfd.application.dto.gfdFuncionario.GfdFuncionarioUpdateObservacaoInputDto;
+import br.com.mili.milibackend.gfd.application.dto.gfdFuncionario.GfdFuncionarioUpdateObservacaoOutputDto;
+
+public interface UpdateObservacaoFuncionarioUseCase {
+    GfdFuncionarioUpdateObservacaoOutputDto execute(GfdFuncionarioUpdateObservacaoInputDto inputDto);
+}

--- a/src/main/java/br/com/mili/milibackend/gfd/domain/usecases/UpdateStatusObservacaoDocumentoUseCase.java
+++ b/src/main/java/br/com/mili/milibackend/gfd/domain/usecases/UpdateStatusObservacaoDocumentoUseCase.java
@@ -1,0 +1,8 @@
+package br.com.mili.milibackend.gfd.domain.usecases;
+
+import br.com.mili.milibackend.gfd.application.dto.gfdDocumento.GfdDocumentoUpdateStatusObservacaoInputDto;
+import br.com.mili.milibackend.gfd.application.dto.gfdDocumento.GfdDocumentoUpdateStatusObservacaoOutputDto;
+
+public interface UpdateStatusObservacaoDocumentoUseCase {
+    GfdDocumentoUpdateStatusObservacaoOutputDto execute(GfdDocumentoUpdateStatusObservacaoInputDto inputDto);
+}

--- a/src/main/java/br/com/mili/milibackend/gfd/infra/projections/GfdFuncionarioDocumentsProjection.java
+++ b/src/main/java/br/com/mili/milibackend/gfd/infra/projections/GfdFuncionarioDocumentsProjection.java
@@ -1,0 +1,9 @@
+package br.com.mili.milibackend.gfd.infra.projections;
+
+public interface GfdFuncionarioDocumentsProjection {
+    Integer getTotalEnviado();
+    Integer getTotalConforme();
+    Integer getTotalNaoConforme();
+    Integer getTotalEmAnalise();
+    Integer getNaoEnviado();
+}

--- a/src/main/java/br/com/mili/milibackend/gfd/infra/repository/gfdFuncionario/GfdFuncionarioLiberacaoRepository.java
+++ b/src/main/java/br/com/mili/milibackend/gfd/infra/repository/gfdFuncionario/GfdFuncionarioLiberacaoRepository.java
@@ -1,0 +1,8 @@
+package br.com.mili.milibackend.gfd.infra.repository.gfdFuncionario;
+
+import br.com.mili.milibackend.gfd.domain.entity.GfdFuncionarioLiberacao;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+
+public interface GfdFuncionarioLiberacaoRepository extends JpaRepository<GfdFuncionarioLiberacao, Integer>, JpaSpecificationExecutor<GfdFuncionarioLiberacao> {
+}

--- a/src/main/java/br/com/mili/milibackend/gfd/infra/repository/gfdFuncionario/GfdFuncionarioRepository.java
+++ b/src/main/java/br/com/mili/milibackend/gfd/infra/repository/gfdFuncionario/GfdFuncionarioRepository.java
@@ -2,6 +2,7 @@ package br.com.mili.milibackend.gfd.infra.repository.gfdFuncionario;
 
 import br.com.mili.milibackend.gfd.domain.entity.GfdFuncionario;
 import br.com.mili.milibackend.gfd.domain.interfaces.IGfdFuncionarioCustomRepository;
+import br.com.mili.milibackend.gfd.infra.projections.GfdFuncionarioDocumentsProjection;
 import br.com.mili.milibackend.gfd.infra.projections.GfdFuncionarioStatusProjection;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
@@ -13,82 +14,82 @@ import java.util.List;
 public interface GfdFuncionarioRepository extends JpaRepository<GfdFuncionario, Integer>, JpaSpecificationExecutor<GfdFuncionario>, IGfdFuncionarioCustomRepository {
 
     String QUERY_GFD_FUNCIONARIO = """
-        SELECT
-            A.ATIVO as ATIVO,
-            A.CTFOR_CODIGO,
-            A.ID_FUNCIONARIO AS ID,
-            A.NOME,
-            A.CPF,
-            A.DATA_NASCIMENTO,
-            A.PAIS_NACIONALIDADE,
-            A.FUNCAO,
-            A.TIPO_CONTRATACAO,
-            A.PERIODO_INICIAL,
-            A.PERIODO_FINAL,
-            A.OBSERVACAO,
-            A.LIBERADO,
-
-            SUM(CASE WHEN C.STATUS = 'ENVIADO'       THEN 1 ELSE 0 END) AS total_enviado,
-            SUM(CASE WHEN C.STATUS = 'CONFORME'      THEN 1 ELSE 0 END) AS total_conforme,
-            SUM(CASE WHEN C.STATUS = 'NAO CONFORME'  THEN 1 ELSE 0 END) AS total_nao_conforme,
-            SUM(CASE WHEN C.STATUS = 'EM ANALISE'    THEN 1 ELSE 0 END) AS total_em_analise,
-            SUM(CASE WHEN C.STATUS IS NULL AND B.OBRIGATORIEDADE = 1 THEN 1 ELSE 0 END) AS nao_enviado
-
-        FROM GFD_FORNECEDOR_FUNCIONARIO A
-        JOIN GFD_TIPO_DOCUMENTO B
-          ON B.TIPO = CASE
-                        WHEN A.TIPO_CONTRATACAO = 'PJ' THEN 'FUNCIONARIO_MEI'
-                        WHEN A.TIPO_CONTRATACAO = 'CLT_SEGURANCA' THEN 'FUNCIONARIO_CLT_SEGURANCA'
-                        ELSE 'FUNCIONARIO_CLT'
-                     END
-
-        LEFT JOIN (
-            SELECT *
-            FROM (
-                SELECT C.*,
-                       ROW_NUMBER() OVER (
-                           PARTITION BY C.CTFOR_CODIGO, C.ID_TIPO_DOCUMENTO, C.ID_FUNCIONARIO
-                           ORDER BY C.ID DESC
-                       ) AS RN
-                FROM CT_FORNECEDOR_DOCUMENTOS C
-                -- Remova este filtro fixo se quiser flexibilidade: WHERE C.CTFOR_CODIGO = 54159
-            ) SUB
-            WHERE SUB.RN = 1
-        ) C
-          ON C.CTFOR_CODIGO = A.CTFOR_CODIGO
-         AND C.ID_TIPO_DOCUMENTO = B.ID
-         AND C.ID_FUNCIONARIO = A.ID_FUNCIONARIO
-
-        WHERE (:idFuncionario IS NULL OR A.ID_FUNCIONARIO = :idFuncionario)
-          AND (:nome IS NULL OR LOWER(A.NOME) LIKE LOWER(:nome))
-          AND A.ATIVO = :ativo
-          AND (:funcao IS NULL OR LOWER(A.FUNCAO) LIKE LOWER(:funcao))
-          AND (:tipoContratacao IS NULL OR A.TIPO_CONTRATACAO = :tipoContratacao)
-          AND (:idFornecedor IS NULL OR A.CTFOR_CODIGO = :idFornecedor)
-          AND (
-                (:periodoInicio IS NULL AND :periodoFim IS NULL)
-             OR (:periodoInicio IS NOT NULL AND :periodoFim IS NOT NULL AND A.PERIODO_INICIAL BETWEEN :periodoInicio AND :periodoFim)
-             OR (:periodoInicio IS NOT NULL AND :periodoFim IS NULL AND A.PERIODO_INICIAL >= :periodoInicio)
-             OR (:periodoInicio IS NULL AND :periodoFim IS NOT NULL AND A.PERIODO_INICIAL <= :periodoFim)
-          )
-
-        GROUP BY
-            A.ATIVO,
-            A.CTFOR_CODIGO,
-            A.ID_FUNCIONARIO,
-            A.NOME,
-            A.CPF,
-            A.DATA_NASCIMENTO,
-            A.PAIS_NACIONALIDADE,
-            A.FUNCAO,
-            A.TIPO_CONTRATACAO,
-            A.PERIODO_INICIAL,
-            A.PERIODO_FINAL,
-            A.LIBERADO,
-            A.OBSERVACAO
-
-        ORDER BY A.ID_FUNCIONARIO
-        """;
+            SELECT
+                A.ATIVO as ATIVO,
+                A.CTFOR_CODIGO,
+                A.ID_FUNCIONARIO AS ID,
+                A.NOME,
+                A.CPF,
+                A.DATA_NASCIMENTO,
+                A.PAIS_NACIONALIDADE,
+                A.FUNCAO,
+                A.TIPO_CONTRATACAO,
+                A.PERIODO_INICIAL,
+                A.PERIODO_FINAL,
+                A.OBSERVACAO,
+                A.LIBERADO,
+            
+                SUM(CASE WHEN C.STATUS = 'ENVIADO'       THEN 1 ELSE 0 END) AS total_enviado,
+                SUM(CASE WHEN C.STATUS = 'CONFORME'      THEN 1 ELSE 0 END) AS total_conforme,
+                SUM(CASE WHEN C.STATUS = 'NAO CONFORME'  THEN 1 ELSE 0 END) AS total_nao_conforme,
+                SUM(CASE WHEN C.STATUS = 'EM ANALISE'    THEN 1 ELSE 0 END) AS total_em_analise,
+                SUM(CASE WHEN C.STATUS IS NULL AND B.OBRIGATORIEDADE = 1 THEN 1 ELSE 0 END) AS nao_enviado
+            
+            FROM GFD_FORNECEDOR_FUNCIONARIO A
+            JOIN GFD_TIPO_DOCUMENTO B
+              ON B.TIPO = CASE
+                            WHEN A.TIPO_CONTRATACAO = 'PJ' THEN 'FUNCIONARIO_MEI'
+                            WHEN A.TIPO_CONTRATACAO = 'CLT_SEGURANCA' THEN 'FUNCIONARIO_CLT_SEGURANCA'
+                            ELSE 'FUNCIONARIO_CLT'
+                         END
+            
+            LEFT JOIN (
+                SELECT *
+                FROM (
+                    SELECT C.*,
+                           ROW_NUMBER() OVER (
+                               PARTITION BY C.CTFOR_CODIGO, C.ID_TIPO_DOCUMENTO, C.ID_FUNCIONARIO
+                               ORDER BY C.ID DESC
+                           ) AS RN
+                    FROM CT_FORNECEDOR_DOCUMENTOS C
+                    -- Remova este filtro fixo se quiser flexibilidade: WHERE C.CTFOR_CODIGO = 54159
+                ) SUB
+                WHERE SUB.RN = 1
+            ) C
+              ON C.CTFOR_CODIGO = A.CTFOR_CODIGO
+             AND C.ID_TIPO_DOCUMENTO = B.ID
+             AND C.ID_FUNCIONARIO = A.ID_FUNCIONARIO
+            
+            WHERE (:idFuncionario IS NULL OR A.ID_FUNCIONARIO = :idFuncionario)
+              AND (:nome IS NULL OR LOWER(A.NOME) LIKE LOWER(:nome))
+              AND A.ATIVO = :ativo
+              AND (:funcao IS NULL OR LOWER(A.FUNCAO) LIKE LOWER(:funcao))
+              AND (:tipoContratacao IS NULL OR A.TIPO_CONTRATACAO = :tipoContratacao)
+              AND (:idFornecedor IS NULL OR A.CTFOR_CODIGO = :idFornecedor)
+              AND (
+                    (:periodoInicio IS NULL AND :periodoFim IS NULL)
+                 OR (:periodoInicio IS NOT NULL AND :periodoFim IS NOT NULL AND A.PERIODO_INICIAL BETWEEN :periodoInicio AND :periodoFim)
+                 OR (:periodoInicio IS NOT NULL AND :periodoFim IS NULL AND A.PERIODO_INICIAL >= :periodoInicio)
+                 OR (:periodoInicio IS NULL AND :periodoFim IS NOT NULL AND A.PERIODO_INICIAL <= :periodoFim)
+              )
+            
+            GROUP BY
+                A.ATIVO,
+                A.CTFOR_CODIGO,
+                A.ID_FUNCIONARIO,
+                A.NOME,
+                A.CPF,
+                A.DATA_NASCIMENTO,
+                A.PAIS_NACIONALIDADE,
+                A.FUNCAO,
+                A.TIPO_CONTRATACAO,
+                A.PERIODO_INICIAL,
+                A.PERIODO_FINAL,
+                A.LIBERADO,
+                A.OBSERVACAO
+            
+            ORDER BY A.ID_FUNCIONARIO
+            """;
 
     @Query(value = QUERY_GFD_FUNCIONARIO + " OFFSET :offset ROWS FETCH NEXT :pageSize ROWS ONLY", nativeQuery = true)
     List<GfdFuncionarioStatusProjection> getAll(
@@ -105,10 +106,10 @@ public interface GfdFuncionarioRepository extends JpaRepository<GfdFuncionario, 
     );
 
     @Query(value = """
-        SELECT COUNT(*) FROM (
-            """ + QUERY_GFD_FUNCIONARIO + """
-        )
-        """, nativeQuery = true)
+                           SELECT COUNT(*) FROM (
+                           """ + QUERY_GFD_FUNCIONARIO + """
+                           )
+                           """, nativeQuery = true)
     Integer getAllCount(
             Integer idFuncionario,
             String nome,
@@ -118,5 +119,43 @@ public interface GfdFuncionarioRepository extends JpaRepository<GfdFuncionario, 
             LocalDate periodoFim,
             Integer idFornecedor,
             Integer ativo
+    );
+
+
+    String QUERY_GFD_FUNCIONARIO_DOCUMENTOS = """
+            SELECT
+                SUM(CASE WHEN C.STATUS = 'ENVIADO'       THEN 1 ELSE 0 END) AS total_enviado,
+                SUM(CASE WHEN C.STATUS = 'CONFORME'      THEN 1 ELSE 0 END) AS total_conforme,
+                SUM(CASE WHEN C.STATUS = 'NAO CONFORME'  THEN 1 ELSE 0 END) AS total_nao_conforme,
+                SUM(CASE WHEN C.STATUS = 'EM ANALISE'    THEN 1 ELSE 0 END) AS total_em_analise,
+                SUM(CASE WHEN C.STATUS IS NULL AND B.OBRIGATORIEDADE = 1 THEN 1 ELSE 0 END) AS nao_enviado
+            FROM GFD_FORNECEDOR_FUNCIONARIO A
+            JOIN GFD_TIPO_DOCUMENTO B
+              ON B.TIPO = CASE
+                            WHEN A.TIPO_CONTRATACAO = 'PJ' THEN 'FUNCIONARIO_MEI'
+                            WHEN A.TIPO_CONTRATACAO = 'CLT_SEGURANCA' THEN 'FUNCIONARIO_CLT_SEGURANCA'
+                            ELSE 'FUNCIONARIO_CLT'
+                         END
+            LEFT JOIN (
+                SELECT *
+                FROM (
+                    SELECT C.*,
+                           ROW_NUMBER() OVER (
+                               PARTITION BY C.CTFOR_CODIGO, C.ID_TIPO_DOCUMENTO, C.ID_FUNCIONARIO
+                               ORDER BY C.ID DESC
+                           ) AS RN
+                    FROM CT_FORNECEDOR_DOCUMENTOS C
+                ) SUB
+                WHERE SUB.RN = 1
+            ) C
+              ON C.CTFOR_CODIGO = A.CTFOR_CODIGO
+             AND C.ID_TIPO_DOCUMENTO = B.ID
+             AND C.ID_FUNCIONARIO = A.ID_FUNCIONARIO
+            WHERE (:idFuncionario IS NULL OR A.ID_FUNCIONARIO = :idFuncionario)
+            ORDER BY A.ID_FUNCIONARIO
+            """;
+    @Query(value = QUERY_GFD_FUNCIONARIO_DOCUMENTOS, nativeQuery = true)
+    GfdFuncionarioDocumentsProjection getAllDocuments(
+            Integer idFuncionario
     );
 }

--- a/src/main/java/br/com/mili/milibackend/shared/roles/GfdRolesConstants.java
+++ b/src/main/java/br/com/mili/milibackend/shared/roles/GfdRolesConstants.java
@@ -3,4 +3,6 @@ package br.com.mili.milibackend.shared.roles;
 public class GfdRolesConstants {
     public static final String ROLE_ANALISTA = "81__ROLE_ANALISTA";
     public static final String ROLE_FORNECEDOR = "81__ROLE_FORNECEDOR";
+    public static final String ROLE_VISUALIZACAO = "81__ROLE_SOMENTE_VISUALIZACAO";
+    public static final String ROLE_SESMT = "81__ROLE_SESMT";
 }

--- a/src/test/java/br/com/mili/milibackend/fornecedor/application/service/GfdFuncionarioServiceTest.java
+++ b/src/test/java/br/com/mili/milibackend/fornecedor/application/service/GfdFuncionarioServiceTest.java
@@ -1,20 +1,17 @@
 package br.com.mili.milibackend.fornecedor.application.service;
 
 import br.com.mili.milibackend.gfd.application.dto.gfdFuncionario.*;
-import br.com.mili.milibackend.gfd.domain.entity.GfdFuncionario;
-import br.com.mili.milibackend.gfd.infra.projections.GfdFuncionarioStatusProjection;
-import br.com.mili.milibackend.gfd.infra.repository.gfdFuncionario.GfdFuncionarioRepository;
 import br.com.mili.milibackend.gfd.application.service.GfdFuncionarioService;
+import br.com.mili.milibackend.gfd.domain.entity.GfdFuncionario;
+import br.com.mili.milibackend.gfd.infra.repository.gfdFuncionario.GfdFuncionarioRepository;
 import br.com.mili.milibackend.shared.exception.types.NotFoundException;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.modelmapper.ModelMapper;
 
-import java.util.List;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -32,64 +29,7 @@ class GfdFuncionarioServiceTest {
     @Mock
     private ModelMapper modelMapper;
 
-    @Test
-    void deve_retornar_pagina_correta_em_getAll_usando_dto_como_projecao() {
-        // Arrange
-        var inputDto = new GfdFuncionarioGetAllInputDto();
-        inputDto.setId(1);
-        inputDto.setNome("João");
-        inputDto.setFuncao("Dev");
-        inputDto.setAtivo(1);
-        inputDto.setFornecedor(new GfdFuncionarioGetAllInputDto.FornecedorDto(99));
-        inputDto.getPageable().setPage(2);
-        inputDto.getPageable().setSize(5);
 
-        var proj1 = Mockito.mock(GfdFuncionarioStatusProjection.class);
-        when(proj1.getCtforCodigo()).thenReturn(99);
-
-        var proj2 = Mockito.mock(GfdFuncionarioStatusProjection.class);
-        when(proj2.getCtforCodigo()).thenReturn(99);
-
-        when(repository.getAll(
-                eq(1), eq("%João%"), eq("%Dev%"),
-                any(), any(), any(),
-                eq(99), eq(1),
-                eq(5), eq(1)
-        )).thenReturn((List<GfdFuncionarioStatusProjection>) List.of(proj1, proj2));
-
-        when(repository.getAllCount(
-                eq(1), eq("João"), eq("Dev"),
-                any(), any(), any(),
-                eq(99), eq(1)
-        )).thenReturn(2);
-
-        var dto1 = GfdFuncionarioGetAllOutputDto.builder()
-                .id(1)
-                .nome("Ana")
-                .funcao("Dev")
-                .fornecedor(new GfdFuncionarioGetAllOutputDto.FornecedorDto(99))
-                .build();
-
-        var dto2 = GfdFuncionarioGetAllOutputDto.builder()
-                .id(2)
-                .nome("Bruno")
-                .funcao("Dev")
-                .fornecedor(new GfdFuncionarioGetAllOutputDto.FornecedorDto(99))
-                .build();
-
-        when(modelMapper.map(proj1, GfdFuncionarioGetAllOutputDto.class)).thenReturn(dto1);
-        when(modelMapper.map(proj2, GfdFuncionarioGetAllOutputDto.class)).thenReturn(dto2);
-
-        // Act
-        var page = service.getAll(inputDto);
-
-        // Assert
-        assertEquals(2, page.getContent().size(), "Deve retornar 2 itens na página");
-        assertEquals(2, page.getPage(), "Deve estar na página 2");
-        assertEquals(5, page.getSize(), "O tamanho da página deve ser 5");
-        assertEquals("Ana", page.getContent().get(0).getNome());
-        assertEquals(99, page.getContent().get(0).getFornecedor().getCodigo());
-    }
 
     @Test
     void deve_criar_e_mapear_novo_funcionario_em_create() {

--- a/src/test/java/br/com/mili/milibackend/gfd/application/service/GfdManagerServiceTest.java
+++ b/src/test/java/br/com/mili/milibackend/gfd/application/service/GfdManagerServiceTest.java
@@ -17,9 +17,9 @@ import br.com.mili.milibackend.gfd.domain.entity.GfdTipoDocumentoTipoEnum;
 import br.com.mili.milibackend.gfd.domain.interfaces.IGfdDocumentoService;
 import br.com.mili.milibackend.gfd.domain.interfaces.IGfdFuncionarioService;
 import br.com.mili.milibackend.gfd.domain.interfaces.IGfdTipoDocumentoService;
+import br.com.mili.milibackend.gfd.domain.usecases.GetAllGfdFuncionarioUseCase;
 import br.com.mili.milibackend.shared.exception.types.ForbiddenException;
 import br.com.mili.milibackend.shared.exception.types.NotFoundException;
-import br.com.mili.milibackend.shared.infra.aws.dto.AttachmentDto;
 import br.com.mili.milibackend.shared.page.pagination.PageBaseImpl;
 import org.apache.tika.Tika;
 import org.junit.jupiter.api.Test;
@@ -33,6 +33,7 @@ import org.modelmapper.ModelMapper;
 import java.time.LocalDate;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 
 import static br.com.mili.milibackend.gfd.adapter.exception.GfdMCodeException.GFD_FORNECEDOR_NAO_ENCONTRADO;
 import static br.com.mili.milibackend.gfd.adapter.exception.GfdMCodeException.GFD_FUNCIONARIO_SEM_PERMISSAO;
@@ -64,6 +65,9 @@ class GfdManagerServiceTest {
 
     @Mock
     private ModelMapper modelMapper;
+
+    @Mock
+    private GetAllGfdFuncionarioUseCase getAllGfdFuncionarioUseCase;
 
     @Mock
     private Tika tika;
@@ -721,17 +725,19 @@ class GfdManagerServiceTest {
         when(modelMapper.map(fornecedorGetByIdDto, Fornecedor.class))
                 .thenReturn(fornecedorEntity);
 
-        var funcionarioEntity = new GfdFuncionarioGetByIdOutputDto();
+        var funcionarioEntity = new GfdFuncionarioGetAllOutputDto();
         funcionarioEntity.setId(idFuncionario);
         funcionarioEntity.setNome("Maria");
-        when(gfdFuncionarioService.getById(idFuncionario))
-                .thenReturn(funcionarioEntity);
+
+
+        when(getAllGfdFuncionarioUseCase.execute(any(GfdFuncionarioGetAllInputDto.class))).thenReturn(new PageBaseImpl<GfdFuncionarioGetAllOutputDto>(List.of(funcionarioEntity), 1, 20, 0));
 
         var funcionarioDto = new GfdMFuncionarioGetOutputDto.GfdFuncionarioDto();
         funcionarioDto.setId(idFuncionario);
         funcionarioDto.setNome("Maria");
         when(modelMapper.map(funcionarioEntity, GfdMFuncionarioGetOutputDto.GfdFuncionarioDto.class))
                 .thenReturn(funcionarioDto);
+
 
         // Act
         var result = gfdManagerService.getFuncionario(inputDto);

--- a/src/test/java/br/com/mili/milibackend/gfd/application/usecases/CreateDocumentoUseCaseImplTest.java
+++ b/src/test/java/br/com/mili/milibackend/gfd/application/usecases/CreateDocumentoUseCaseImplTest.java
@@ -1,18 +1,9 @@
 package br.com.mili.milibackend.gfd.application.usecases;
 
-import br.com.mili.milibackend.fornecedor.infra.repository.fornecedorRepository.FornecedorRepository;
 import br.com.mili.milibackend.gfd.application.dto.gfdDocumento.GfdDocumentoCreateInputDto;
 import br.com.mili.milibackend.gfd.application.dto.gfdDocumento.GfdDocumentoCreateOutputDto;
 import br.com.mili.milibackend.gfd.domain.entity.GfdDocumento;
-import br.com.mili.milibackend.gfd.domain.interfaces.FileProcessingService;
-import br.com.mili.milibackend.gfd.domain.usecases.CreateDocumentoUseCase;
-import br.com.mili.milibackend.gfd.infra.repository.GfdTipoDocumentoRepository;
 import br.com.mili.milibackend.gfd.infra.repository.gfdDocumento.GfdDocumentoRepository;
-import br.com.mili.milibackend.shared.infra.aws.IS3Service;
-import br.com.mili.milibackend.shared.infra.aws.S3ServiceImpl;
-import br.com.mili.milibackend.shared.infra.aws.StorageFolderEnum;
-import br.com.mili.milibackend.shared.infra.aws.dto.AttachmentDto;
-import com.google.gson.Gson;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -20,9 +11,8 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.modelmapper.ModelMapper;
 
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -34,7 +24,6 @@ class CreateDocumentoUseCaseImplTest {
 
     @Mock
     private ModelMapper modelMapper;
-
 
     @InjectMocks
     private CreateDocumentoUseCaseImpl useCase;

--- a/src/test/java/br/com/mili/milibackend/gfd/application/usecases/GetAllGfdFuncionarioUseCaseImplTest.java
+++ b/src/test/java/br/com/mili/milibackend/gfd/application/usecases/GetAllGfdFuncionarioUseCaseImplTest.java
@@ -1,0 +1,93 @@
+package br.com.mili.milibackend.gfd.application.usecases;
+
+import br.com.mili.milibackend.gfd.application.dto.gfdFuncionario.GfdFuncionarioGetAllInputDto;
+import br.com.mili.milibackend.gfd.application.dto.gfdFuncionario.GfdFuncionarioGetAllOutputDto;
+import br.com.mili.milibackend.gfd.infra.projections.GfdFuncionarioStatusProjection;
+import br.com.mili.milibackend.gfd.infra.repository.gfdFuncionario.GfdFuncionarioRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.modelmapper.ModelMapper;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+@ExtendWith(MockitoExtension.class)
+
+class GetAllGfdFuncionarioUseCaseImplTest {
+
+    @InjectMocks
+    private GetAllGfdFuncionarioUseCaseImpl service;
+
+    @Mock
+    private GfdFuncionarioRepository repository;
+
+    @Mock
+    private ModelMapper modelMapper;
+
+
+    @Test
+    void deve_retornar_pagina_correta_em_getAll_usando_dto_como_projecao() {
+        // Arrange
+        var inputDto = new GfdFuncionarioGetAllInputDto();
+        inputDto.setId(1);
+        inputDto.setNome("João");
+        inputDto.setFuncao("Dev");
+        inputDto.setAtivo(1);
+        inputDto.setFornecedor(new GfdFuncionarioGetAllInputDto.FornecedorDto(99));
+        inputDto.getPageable().setPage(2);
+        inputDto.getPageable().setSize(5);
+
+        var proj1 = Mockito.mock(GfdFuncionarioStatusProjection.class);
+        when(proj1.getCtforCodigo()).thenReturn(99);
+
+        var proj2 = Mockito.mock(GfdFuncionarioStatusProjection.class);
+        when(proj2.getCtforCodigo()).thenReturn(99);
+
+        when(repository.getAll(
+                eq(1), eq("%João%"), eq("%Dev%"),
+                any(), any(), any(),
+                eq(99), eq(1),
+                eq(5), eq(1)
+        )).thenReturn((List<GfdFuncionarioStatusProjection>) List.of(proj1, proj2));
+
+        when(repository.getAllCount(
+                eq(1), eq("João"), eq("Dev"),
+                any(), any(), any(),
+                eq(99), eq(1)
+        )).thenReturn(2);
+
+        var dto1 = GfdFuncionarioGetAllOutputDto.builder()
+                .id(1)
+                .nome("Ana")
+                .funcao("Dev")
+                .fornecedor(new GfdFuncionarioGetAllOutputDto.FornecedorDto(99))
+                .build();
+
+        var dto2 = GfdFuncionarioGetAllOutputDto.builder()
+                .id(2)
+                .nome("Bruno")
+                .funcao("Dev")
+                .fornecedor(new GfdFuncionarioGetAllOutputDto.FornecedorDto(99))
+                .build();
+
+        when(modelMapper.map(proj1, GfdFuncionarioGetAllOutputDto.class)).thenReturn(dto1);
+        when(modelMapper.map(proj2, GfdFuncionarioGetAllOutputDto.class)).thenReturn(dto2);
+
+        // Act
+        var page = service.execute(inputDto);
+
+        // Assert
+        assertEquals(2, page.getContent().size(), "Deve retornar 2 itens na página");
+        assertEquals(2, page.getPage(), "Deve estar na página 2");
+        assertEquals(5, page.getSize(), "O tamanho da página deve ser 5");
+        assertEquals("Ana", page.getContent().get(0).getNome());
+        assertEquals(99, page.getContent().get(0).getFornecedor().getCodigo());
+    }
+}

--- a/src/test/java/br/com/mili/milibackend/gfd/application/usecases/LiberarFuncionarioUseCaseImplTest.java
+++ b/src/test/java/br/com/mili/milibackend/gfd/application/usecases/LiberarFuncionarioUseCaseImplTest.java
@@ -1,0 +1,157 @@
+package br.com.mili.milibackend.gfd.application.usecases;
+
+import br.com.mili.milibackend.gfd.adapter.exception.GfdFuncionarioCodeException;
+import br.com.mili.milibackend.gfd.application.dto.gfdFuncionario.GfdFuncionarioLiberarInputDto;
+import br.com.mili.milibackend.gfd.application.dto.gfdFuncionario.GfdFuncionarioLiberarOutputDto;
+import br.com.mili.milibackend.gfd.domain.entity.GfdFuncionario;
+import br.com.mili.milibackend.gfd.domain.entity.GfdFuncionarioLiberacao;
+import br.com.mili.milibackend.gfd.infra.projections.GfdFuncionarioDocumentsProjection;
+import br.com.mili.milibackend.gfd.infra.repository.gfdFuncionario.GfdFuncionarioLiberacaoRepository;
+import br.com.mili.milibackend.gfd.infra.repository.gfdFuncionario.GfdFuncionarioRepository;
+import br.com.mili.milibackend.shared.exception.types.NotFoundException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.modelmapper.ModelMapper;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class LiberarFuncionarioUseCaseImplTest {
+
+    @Mock
+    private GfdFuncionarioRepository funcionarioRepository;
+
+    @Mock
+    private GfdFuncionarioLiberacaoRepository liberacaoRepository;
+
+    @Mock
+    private ModelMapper modelMapper;
+
+    @InjectMocks
+    private LiberarFuncionarioUseCaseImpl useCase;
+
+    @Captor
+    private ArgumentCaptor<GfdFuncionarioLiberacao> liberacaoCaptor;
+
+    private GfdFuncionario funcionario;
+
+    @BeforeEach
+    void setup() {
+        funcionario = new GfdFuncionario();
+        funcionario.setId(1);
+        funcionario.setLiberado(0);
+    }
+
+    @Test
+    void teste_deve_lancar_excecao_quando_funcionario_nao_for_encontrado() {
+        when(funcionarioRepository.findById(1)).thenReturn(Optional.empty());
+
+        var input = new GfdFuncionarioLiberarInputDto();
+        input.setId(1);
+
+        NotFoundException ex = assertThrows(NotFoundException.class, () -> useCase.execute(input));
+        assertEquals(GfdFuncionarioCodeException.GFD_FUNCIONARIO_NAO_ENCONTRADO.getMensagem(), ex.getMessage());
+
+        verify(funcionarioRepository).findById(1);
+        verifyNoMoreInteractions(funcionarioRepository, liberacaoRepository);
+    }
+
+    @Test
+    void teste_deve_lancar_excecao_quando_documentos_pendentes_e_justificativa_vazia() {
+        when(funcionarioRepository.findById(1)).thenReturn(Optional.of(funcionario));
+
+        GfdFuncionarioDocumentsProjection documentosMock = mock(GfdFuncionarioDocumentsProjection.class);
+        when(documentosMock.getTotalEnviado()).thenReturn(1);
+
+
+        when(funcionarioRepository.getAllDocuments(1)).thenReturn(documentosMock);
+
+        var input = new GfdFuncionarioLiberarInputDto();
+        input.setId(1);
+        input.setJustificativa("");
+        input.setLiberado(1);
+
+        NotFoundException ex = assertThrows(NotFoundException.class, () -> useCase.execute(input));
+        assertEquals(GfdFuncionarioCodeException.GFD_FUNCIONARIO_LIBERACAO_COM_DOCUMENTO_PENDENTE.getMensagem(), ex.getMessage());
+
+        verify(funcionarioRepository).findById(1);
+        verify(funcionarioRepository).getAllDocuments(1);
+        verifyNoMoreInteractions(liberacaoRepository);
+    }
+
+    @Test
+    void teste_deve_liberar_funcionario_quando_documentos_pendentes_e_justificativa_preenchida() {
+        when(funcionarioRepository.findById(1)).thenReturn(Optional.of(funcionario));
+
+        GfdFuncionarioDocumentsProjection documentosMock = mock(GfdFuncionarioDocumentsProjection.class);
+        when(documentosMock.getTotalEnviado()).thenReturn(1);
+
+        when(funcionarioRepository.getAllDocuments(1)).thenReturn(documentosMock);
+
+
+        var input = new GfdFuncionarioLiberarInputDto();
+        input.setId(1);
+        input.setJustificativa("Justificativa válida");
+        input.setLiberado(1);
+        input.setUsuario(12345);
+
+        when(funcionarioRepository.save(any())).thenReturn(funcionario);
+        when(modelMapper.map(any(), eq(GfdFuncionarioLiberarOutputDto.class))).thenReturn(new GfdFuncionarioLiberarOutputDto());
+
+        var output = useCase.execute(input);
+
+        assertNotNull(output);
+        assertEquals(1, funcionario.getLiberado());
+
+        verify(funcionarioRepository).findById(1);
+        verify(funcionarioRepository).getAllDocuments(1);
+        verify(funcionarioRepository).save(funcionario);
+        verify(liberacaoRepository).save(liberacaoCaptor.capture());
+
+        var liberacaoSalva = liberacaoCaptor.getValue();
+        assertEquals(funcionario, liberacaoSalva.getFuncionario());
+        assertEquals(input.getLiberado(), liberacaoSalva.getStatusLiberado());
+        assertEquals(input.getJustificativa(), liberacaoSalva.getJustificativa());
+        assertEquals(input.getUsuario(), liberacaoSalva.getUsuario());
+    }
+
+    @Test
+    void teste_deve_liberar_funcionario_quando_nao_existirem_documentos_pendentes() {
+        when(funcionarioRepository.findById(1)).thenReturn(Optional.of(funcionario));
+
+        GfdFuncionarioDocumentsProjection documentosMock = mock(GfdFuncionarioDocumentsProjection.class);
+        when(documentosMock.getTotalEnviado()).thenReturn(0);
+
+        when(funcionarioRepository.getAllDocuments(1)).thenReturn(documentosMock);
+
+        var input = new GfdFuncionarioLiberarInputDto();
+        input.setId(1);
+        input.setLiberado(1);
+        input.setJustificativa(null);
+        input.setUsuario(12345);
+
+        when(funcionarioRepository.save(any())).thenReturn(funcionario);
+        when(modelMapper.map(any(), eq(GfdFuncionarioLiberarOutputDto.class))).thenReturn(new GfdFuncionarioLiberarOutputDto());
+
+        var output = useCase.execute(input);
+
+        assertNotNull(output);
+        assertEquals(1, funcionario.getLiberado());
+
+        verify(funcionarioRepository).findById(1);
+        verify(funcionarioRepository).getAllDocuments(1);
+        verify(funcionarioRepository).save(funcionario);
+        verify(liberacaoRepository).save(any());
+    }
+}


### PR DESCRIPTION
📌 Solicitação
-

**43992** – Favor liberar um acesso apenas de conferencia

**43956** – Apresentar mensagem para liberar o funcionário, caso existam documentos não validados (Status Conforme).Gravar no log quem liberou, junto com a mensagem.

**44002** – liberar um acesso para portaria  apenas para visualização e consulta de telas de todos terceiros

**43662**– deixar a opção selecionada quando o fornecedor clicar e concordar com os termos LGPD. 

 ✅ Solução
-

**43992** 
- Adicionado fluxo para usuários com role = SESMT
- Alterado hasAuthority para separar corretamente as roles
- Criado novo usecase para os usuários sesmt fazerem suas observações e alterar o status

**43956** 
- Adicionado nova rota para liberar os funcionários (/liberar)
- extraído funcionarios getall para usecase
- Criado novo usecase para usuários fazerem apenas a observação dos funcionários

**44002** 
- Alterado hasAuthority em algumas rotas para apenas visualização 

**43662** 
- Agora é salvo e retornado o aceite lgpd 
