### PR TITLE
feat: 43960 implement filter documents | refactor: extract methods (DocumentoService, TiposDocumento, GfdManager) | fix 44318: accents are removed when saving the files

### DIFF
--- a/src/main/java/br/com/mili/milibackend/fornecedor/application/usecases/GetFornecedorByCodOrIdUseCaseImpl.java
+++ b/src/main/java/br/com/mili/milibackend/fornecedor/application/usecases/GetFornecedorByCodOrIdUseCaseImpl.java
@@ -1,0 +1,32 @@
+package br.com.mili.milibackend.fornecedor.application.usecases;
+
+import br.com.mili.milibackend.fornecedor.domain.entity.Fornecedor;
+import br.com.mili.milibackend.fornecedor.domain.usecases.GetFornecedorByCodOrIdUseCase;
+import br.com.mili.milibackend.fornecedor.infra.repository.fornecedorRepository.FornecedorRepository;
+import br.com.mili.milibackend.shared.exception.types.NotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import static br.com.mili.milibackend.gfd.adapter.exception.GfdMCodeException.GFD_FORNECEDOR_NAO_ENCONTRADO;
+
+@Service
+@RequiredArgsConstructor
+public class GetFornecedorByCodOrIdUseCaseImpl implements GetFornecedorByCodOrIdUseCase {
+    private final FornecedorRepository fornecedorRepository;
+
+    public Fornecedor execute(Integer codUsuario, Integer id) {
+        Fornecedor fornecedor = null;
+
+        if (id != null) {
+            fornecedor = fornecedorRepository.findById(id).orElse(null);
+        } else if (codUsuario != null) {
+            fornecedor = fornecedorRepository.findByCodUsuario(codUsuario).orElse(null);
+        }
+
+        if (fornecedor == null) {
+            throw new NotFoundException(GFD_FORNECEDOR_NAO_ENCONTRADO.getMensagem(), GFD_FORNECEDOR_NAO_ENCONTRADO.getCode());
+        }
+
+        return fornecedor;
+    }
+}

--- a/src/main/java/br/com/mili/milibackend/fornecedor/domain/usecases/GetFornecedorByCodOrIdUseCase.java
+++ b/src/main/java/br/com/mili/milibackend/fornecedor/domain/usecases/GetFornecedorByCodOrIdUseCase.java
@@ -1,0 +1,7 @@
+package br.com.mili.milibackend.fornecedor.domain.usecases;
+
+import br.com.mili.milibackend.fornecedor.domain.entity.Fornecedor;
+
+public interface GetFornecedorByCodOrIdUseCase {
+    Fornecedor execute(Integer codUsuario, Integer id);
+}

--- a/src/main/java/br/com/mili/milibackend/gfd/adapter/exception/GfdMCodeException.java
+++ b/src/main/java/br/com/mili/milibackend/gfd/adapter/exception/GfdMCodeException.java
@@ -10,7 +10,9 @@ public enum GfdMCodeException {
     GFD_FORNECEDOR_NAO_ENCONTRADO("GFD_FORNECEDOR_NAO_ENCONTRADO", "Fornecedor não encontrado"),
     GFD_TIPO_DOCUMENTO_FUNCIONARIO_BAD_REQUEST("GFD_TIPO_DOCUMENTO_FUNCIONARIO_BAD_REQUEST", "Tipo de documento não pode ser de fornecedor, quando enviar o funcionário id"),
     GFD_TIPO_DOCUMENTO_NAO_ENCONTRADO("GFD_TIPO_DOCUMENTO__NAO_ENCONTRADO", "Tipo de documento não encontrado"),
-    GFD_FUNCIONARIO_SEM_PERMISSAO("GFD_FUNCIONARIO_SEM_PERMISSAO", "Você não tem permissão para realizar essa operação");
+    GFD_TIPO_DOCUMENTO_REGISTROS_ENCONTRADOS_VALIDADE("GFD_TIPO_DOCUMENTO_REGISTROS_ENCONTRADOS_VALIDADE", "Existes registros que usa esse tipo de documento, impossibilitando a alteração da validade"),
+    GFD_FUNCIONARIO_SEM_PERMISSAO("GFD_FUNCIONARIO_SEM_PERMISSAO", "Você não tem permissão para realizar essa operação"),
+    GFD_PERIODO_VAZIO("GFD_PERIODO_VAZIO", "O campo GfdDocumentoPeriodo deve estar preenchido");
 
     private final String code;
     private final String mensagem;

--- a/src/main/java/br/com/mili/milibackend/gfd/adapter/web/controller/GfdTipoDocumentoController.java
+++ b/src/main/java/br/com/mili/milibackend/gfd/adapter/web/controller/GfdTipoDocumentoController.java
@@ -3,6 +3,7 @@ package br.com.mili.milibackend.gfd.adapter.web.controller;
 
 import br.com.mili.milibackend.gfd.application.dto.gfdTipoDocumento.*;
 import br.com.mili.milibackend.gfd.domain.interfaces.IGfdTipoDocumentoService;
+import br.com.mili.milibackend.gfd.domain.usecases.GetAllTipoDocumentoUseCase;
 import br.com.mili.milibackend.shared.infra.security.model.CustomUserPrincipal;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -26,6 +27,7 @@ public class GfdTipoDocumentoController {
     protected static final String ENDPOINT = "/mili-backend/v1/gfd/tipo-documentos";
 
     private final IGfdTipoDocumentoService gfdTipoDocumentoService;
+    private final GetAllTipoDocumentoUseCase getAllTipoDocumentoUseCase ;
 
        @PreAuthorize("hasAuthority('" + ROLE_ANALISTA + "') " +
                   "or hasAuthority('" + ROLE_FORNECEDOR + "')" +
@@ -39,7 +41,7 @@ public class GfdTipoDocumentoController {
     ) {
         log.info("{} {}/{}", RequestMethod.GET, ENDPOINT, user.getUsername());
 
-        return ResponseEntity.ok(gfdTipoDocumentoService.getAll(inputDto));
+        return ResponseEntity.ok(getAllTipoDocumentoUseCase.execute(inputDto));
     }
 
        @PreAuthorize("hasAuthority('" + ROLE_ANALISTA + "') " +

--- a/src/main/java/br/com/mili/milibackend/gfd/application/dto/GfdMDocumentoUpdateInputDto.java
+++ b/src/main/java/br/com/mili/milibackend/gfd/application/dto/GfdMDocumentoUpdateInputDto.java
@@ -16,6 +16,7 @@ public class GfdMDocumentoUpdateInputDto {
     private GfdDocumentoUpdateInputDto documento;
     private FornecedorDto fornecedor;
     private Integer codUsuario;
+    private GfdDocumentoPeriodoDto gfdDocumentoPeriodo;
 
     @AllArgsConstructor
     @NoArgsConstructor
@@ -45,6 +46,14 @@ public class GfdMDocumentoUpdateInputDto {
     public static class FornecedorDto {
         private Integer id;
 
+    }
+
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Getter
+    @Setter
+    public static class GfdDocumentoPeriodoDto {
+        private LocalDate periodo;
     }
 
 }

--- a/src/main/java/br/com/mili/milibackend/gfd/application/dto/GfdMDocumentoUpdateOutputDto.java
+++ b/src/main/java/br/com/mili/milibackend/gfd/application/dto/GfdMDocumentoUpdateOutputDto.java
@@ -32,7 +32,7 @@ public class GfdMDocumentoUpdateOutputDto {
         private String observacao;
         private GfdDocumentoStatusEnum status;
         private GfdTipoDocumentoDto gfdTipoDocumento;
-
+        private GfdDocumentoPeriodoDto gfdDocumentoPeriodo;
 
         @AllArgsConstructor
         @NoArgsConstructor
@@ -42,6 +42,15 @@ public class GfdMDocumentoUpdateOutputDto {
             private Integer id;
             private String nome;
             private Integer diasValidade;
+        }
+
+        @AllArgsConstructor
+        @NoArgsConstructor
+        @Getter
+        @Setter
+        public static class GfdDocumentoPeriodoDto {
+            private Integer id;
+            private LocalDate periodo;
         }
     }
 }

--- a/src/main/java/br/com/mili/milibackend/gfd/application/dto/GfdMDocumentosGetAllInputDto.java
+++ b/src/main/java/br/com/mili/milibackend/gfd/application/dto/GfdMDocumentosGetAllInputDto.java
@@ -33,6 +33,8 @@ public class GfdMDocumentosGetAllInputDto extends Filtro {
     private LocalDate dataEmissaoInic;
     private LocalDate dataEmissaoFinal;
 
+    private LocalDate periodo;
+
     private Integer tipoDocumentoId;
     private FuncionarioDto funcionario;
 

--- a/src/main/java/br/com/mili/milibackend/gfd/application/dto/GfdMDocumentosGetAllOutputDto.java
+++ b/src/main/java/br/com/mili/milibackend/gfd/application/dto/GfdMDocumentosGetAllOutputDto.java
@@ -1,7 +1,10 @@
 package br.com.mili.milibackend.gfd.application.dto;
 
+import br.com.mili.milibackend.gfd.domain.entity.GfdDocumento;
+import br.com.mili.milibackend.gfd.domain.entity.GfdDocumentoPeriodo;
 import br.com.mili.milibackend.gfd.domain.entity.GfdDocumentoStatusEnum;
 import br.com.mili.milibackend.shared.page.pagination.MyPage;
+import jakarta.persistence.*;
 import lombok.*;
 
 import java.time.LocalDate;
@@ -14,6 +17,8 @@ import java.time.LocalDate;
 public class GfdMDocumentosGetAllOutputDto {
     private MyPage<GfdDocumentoDto> gfdDocumento;
     private GfdTipoDocumentoDto gfdTipoDocumento;
+
+
     private Integer nextDoc;
     private Integer previousDoc;
 
@@ -21,11 +26,13 @@ public class GfdMDocumentosGetAllOutputDto {
     @NoArgsConstructor
     @Getter
     @Setter
-    public static class  GfdTipoDocumentoDto {
+    public static class GfdTipoDocumentoDto {
         private Integer id;
         private String nome;
         private Integer diasValidade;
+        private String classificacao;
     }
+
 
     @AllArgsConstructor
     @NoArgsConstructor
@@ -45,6 +52,7 @@ public class GfdMDocumentosGetAllOutputDto {
         private String tipoArquivo;
         private GfdDocumentoStatusEnum status;
         private GfdTipoDocumentoDto gfdTipoDocumento;
+        private GfdDocumentoPeriodoDto gfdDocumentoPeriodo;
 
         @AllArgsConstructor
         @NoArgsConstructor
@@ -52,8 +60,16 @@ public class GfdMDocumentosGetAllOutputDto {
         @Setter
         public static class GfdTipoDocumentoDto {
             private Integer id;
-            private String nome;
-            private Integer diasValidade;
         }
+
+        @AllArgsConstructor
+        @NoArgsConstructor
+        @Getter
+        @Setter
+        public static class GfdDocumentoPeriodoDto {
+            private Integer id;
+            private LocalDate periodo;
+        }
+
     }
 }

--- a/src/main/java/br/com/mili/milibackend/gfd/application/dto/GfdMFuncionarioCreateInputDto.java
+++ b/src/main/java/br/com/mili/milibackend/gfd/application/dto/GfdMFuncionarioCreateInputDto.java
@@ -12,6 +12,7 @@ import java.time.LocalDate;
 public class GfdMFuncionarioCreateInputDto {
     private Integer codUsuario;
     private GfdFuncionarioDto funcionario;
+    private GfdDocumentoPeriodoDto gfdDocumentoPeriodo;
 
     @Getter
     @AllArgsConstructor
@@ -38,5 +39,13 @@ public class GfdMFuncionarioCreateInputDto {
         public static class FornecedorDto {
             private Integer codigo;
         }
+    }
+
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Getter
+    @Setter
+    public static class GfdDocumentoPeriodoDto {
+        private LocalDate periodo;
     }
 }

--- a/src/main/java/br/com/mili/milibackend/gfd/application/dto/GfdMUploadDocumentoInputDto.java
+++ b/src/main/java/br/com/mili/milibackend/gfd/application/dto/GfdMUploadDocumentoInputDto.java
@@ -24,6 +24,8 @@ public class GfdMUploadDocumentoInputDto {
     private GfdDocumentoDto gfdDocumento;
     private GfdTipoDocumentoDto gfdTipoDocumento;
     private GfdFuncionarioDto funcionario;
+    private GfdDocumentoPeriodoDto gfdDocumentoPeriodo;
+
 
     @NoArgsConstructor
     @AllArgsConstructor
@@ -31,6 +33,14 @@ public class GfdMUploadDocumentoInputDto {
     @Setter
     public static class GfdFuncionarioDto {
         private Integer id;
+    }
+
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Getter
+    @Setter
+    public static class GfdDocumentoPeriodoDto {
+        private LocalDate periodo;
     }
 
     @NoArgsConstructor

--- a/src/main/java/br/com/mili/milibackend/gfd/application/dto/GfdMVerificarDocumentosInputDto.java
+++ b/src/main/java/br/com/mili/milibackend/gfd/application/dto/GfdMVerificarDocumentosInputDto.java
@@ -5,6 +5,8 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
+import java.time.LocalDate;
+
 @NoArgsConstructor
 @AllArgsConstructor
 @Getter
@@ -13,4 +15,6 @@ public class GfdMVerificarDocumentosInputDto {
     private Integer codUsuario;
     private Integer idFuncionario;
     private Integer id;
+
+    private LocalDate periodo;
 }

--- a/src/main/java/br/com/mili/milibackend/gfd/application/dto/gfdDocumento/GfdDocumentoGetAllInputDto.java
+++ b/src/main/java/br/com/mili/milibackend/gfd/application/dto/gfdDocumento/GfdDocumentoGetAllInputDto.java
@@ -24,6 +24,8 @@ public class GfdDocumentoGetAllInputDto extends Filtro {
     private LocalDate dataEmissaoInic;
     private LocalDate dataEmissaoFinal;
 
+    private LocalDate periodo;
+
     private Integer tipoDocumentoId;
 
     private String usuario;

--- a/src/main/java/br/com/mili/milibackend/gfd/application/dto/gfdDocumento/GfdDocumentoUpdateInputDto.java
+++ b/src/main/java/br/com/mili/milibackend/gfd/application/dto/gfdDocumento/GfdDocumentoUpdateInputDto.java
@@ -1,6 +1,6 @@
 package br.com.mili.milibackend.gfd.application.dto.gfdDocumento;
 
-import br.com.mili.milibackend.fornecedor.domain.entity.Fornecedor;
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 import lombok.*;
 
@@ -12,18 +12,75 @@ import java.time.LocalDate;
 @Setter
 @EqualsAndHashCode
 public class GfdDocumentoUpdateInputDto {
+    private GfdDocumentoPeriodoDto gfdDocumentoPeriodo;
 
     @NotNull
-    private Integer id;
+    @Valid
+    private GfdDocumentoDto gfdDocumentoDto;
 
-    @NotNull
-    private LocalDate dataEmissao;
+    public static Builder builder() {
+        return new Builder();
+    }
 
-    private LocalDate dataValidade;
+    public static class Builder {
+        private LocalDate periodo;
+        private Integer idDocumento;
+        private LocalDate dataEmissao;
+        private LocalDate dataValidade;
+        private String status;
+        private String observacao;
 
-    @NotNull
-    private String status;
+        public Builder periodo(LocalDate periodo) {
+            this.periodo = periodo;
+            return this;
+        }
 
-    private String observacao;
+        public Builder documento(Integer id,
+                                 LocalDate dataEmissao,
+                                 LocalDate dataValidade,
+                                 String status,
+                                 String observacao) {
+            this.idDocumento = id;
+            this.dataEmissao = dataEmissao;
+            this.dataValidade = dataValidade;
+            this.status = status;
+            this.observacao = observacao;
+            return this;
+        }
 
+        public GfdDocumentoUpdateInputDto build() {
+            return new GfdDocumentoUpdateInputDto(
+                    new GfdDocumentoPeriodoDto(periodo),
+                    new GfdDocumentoDto(idDocumento, dataEmissao, dataValidade, status, observacao)
+            );
+        }
+    }
+
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Getter
+    @Setter
+    public static class GfdDocumentoDto {
+        @NotNull
+        private Integer id;
+
+        @NotNull
+        private LocalDate dataEmissao;
+
+        private LocalDate dataValidade;
+
+        @NotNull
+        private String status;
+
+        private String observacao;
+    }
+
+
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Getter
+    @Setter
+    public static class GfdDocumentoPeriodoDto {
+        private LocalDate periodo;
+    }
 }

--- a/src/main/java/br/com/mili/milibackend/gfd/application/dto/gfdDocumentoPeriodo/GfdDocumentoPeriodoCreateInputDto.java
+++ b/src/main/java/br/com/mili/milibackend/gfd/application/dto/gfdDocumentoPeriodo/GfdDocumentoPeriodoCreateInputDto.java
@@ -1,0 +1,94 @@
+package br.com.mili.milibackend.gfd.application.dto.gfdDocumentoPeriodo;
+
+import lombok.*;
+
+import java.time.LocalDate;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class GfdDocumentoPeriodoCreateInputDto {
+    private GfdDocumentoPeriodoDto gfdDocumentoPeriodo;
+    private GfdDocumentoDto gfdDocumentoDto;
+    private TipoDocumentoDto tipoDocumento;
+    private boolean isUpdate = false;
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+        private LocalDate periodo;
+        private LocalDate dataEmissao;
+        private String classificacao;
+        private Integer diasValidade;
+        private LocalDate dataValidade;
+        private Integer idTipoDocumento;
+        private Integer idDocumento;
+        private boolean isUpdate = false;
+
+        public Builder update() {
+            this.isUpdate = true;
+            return this;
+        }
+
+
+        public Builder periodo(LocalDate periodo) {
+            this.periodo = periodo;
+            return this;
+        }
+
+        public Builder documento(Integer idDocumento, LocalDate dataEmissao, LocalDate dataValidade) {
+            this.idDocumento = idDocumento;
+            this.dataEmissao = dataEmissao;
+            this.dataValidade = dataValidade;
+            return this;
+        }
+
+        public Builder tipoDocumento(Integer id ,String classificacao, Integer diasValidade) {
+            this.idTipoDocumento = id;
+            this.classificacao = classificacao;
+            this.diasValidade = diasValidade;
+            return this;
+        }
+
+        public GfdDocumentoPeriodoCreateInputDto build() {
+            return new GfdDocumentoPeriodoCreateInputDto(
+                    new GfdDocumentoPeriodoDto(periodo),
+                    new GfdDocumentoDto(idDocumento, dataEmissao, dataValidade),
+                    new TipoDocumentoDto(idTipoDocumento, classificacao, diasValidade),
+                    isUpdate
+            );
+        }
+    }
+
+    @Getter
+    @Setter
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class TipoDocumentoDto {
+        private Integer id;
+        private String classificacao;
+        private Integer diasValidade;
+    }
+
+
+    @Getter
+    @Setter
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class GfdDocumentoDto {
+        private Integer id;
+        private LocalDate dataEmissao;
+        private LocalDate dataValidade;
+    }
+
+    @Getter
+    @Setter
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class GfdDocumentoPeriodoDto {
+        private LocalDate periodo;
+    }
+}

--- a/src/main/java/br/com/mili/milibackend/gfd/application/dto/gfdDocumentoPeriodo/GfdDocumentoPeriodoCreateOutputDto.java
+++ b/src/main/java/br/com/mili/milibackend/gfd/application/dto/gfdDocumentoPeriodo/GfdDocumentoPeriodoCreateOutputDto.java
@@ -1,0 +1,25 @@
+package br.com.mili.milibackend.gfd.application.dto.gfdDocumentoPeriodo;
+
+import br.com.mili.milibackend.gfd.domain.entity.GfdDocumento;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDate;
+
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class GfdDocumentoPeriodoCreateOutputDto {
+    private Integer id;
+
+    private GfdDocumento gfdDocumento;
+
+    private LocalDate periodoInicial;
+
+    private LocalDate periodoFinal;
+}

--- a/src/main/java/br/com/mili/milibackend/gfd/application/dto/gfdFuncionario/GfdFuncionarioLiberarInputDto.java
+++ b/src/main/java/br/com/mili/milibackend/gfd/application/dto/gfdFuncionario/GfdFuncionarioLiberarInputDto.java
@@ -1,7 +1,6 @@
 package br.com.mili.milibackend.gfd.application.dto.gfdFuncionario;
 
 
-import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 import lombok.*;
 

--- a/src/main/java/br/com/mili/milibackend/gfd/application/dto/gfdTipoDocumento/GfdTipoDocumentoCreateInputDto.java
+++ b/src/main/java/br/com/mili/milibackend/gfd/application/dto/gfdTipoDocumento/GfdTipoDocumentoCreateInputDto.java
@@ -19,4 +19,6 @@ public class GfdTipoDocumentoCreateInputDto {
 
     private Boolean obrigatoriedade;
 
+    private String classificacao;
+
 }

--- a/src/main/java/br/com/mili/milibackend/gfd/application/dto/gfdTipoDocumento/GfdTipoDocumentoCreateOutputDto.java
+++ b/src/main/java/br/com/mili/milibackend/gfd/application/dto/gfdTipoDocumento/GfdTipoDocumentoCreateOutputDto.java
@@ -22,4 +22,7 @@ public class GfdTipoDocumentoCreateOutputDto {
         private Boolean obrigatoriedade;
 
         private Boolean ativo;
+
+        private String classificacao;
+
 }

--- a/src/main/java/br/com/mili/milibackend/gfd/application/dto/gfdTipoDocumento/GfdTipoDocumentoGetAllOutputDto.java
+++ b/src/main/java/br/com/mili/milibackend/gfd/application/dto/gfdTipoDocumento/GfdTipoDocumentoGetAllOutputDto.java
@@ -22,4 +22,6 @@ public class GfdTipoDocumentoGetAllOutputDto {
     private Boolean obrigatoriedade;
 
     private Boolean ativo;
+
+    private String classificacao;
 }

--- a/src/main/java/br/com/mili/milibackend/gfd/application/dto/gfdTipoDocumento/GfdTipoDocumentoGetByIdOutputDto.java
+++ b/src/main/java/br/com/mili/milibackend/gfd/application/dto/gfdTipoDocumento/GfdTipoDocumentoGetByIdOutputDto.java
@@ -22,4 +22,6 @@ public class GfdTipoDocumentoGetByIdOutputDto {
     private Boolean obrigatoriedade;
 
     private Boolean ativo;
+
+    private String classificacao;
 }

--- a/src/main/java/br/com/mili/milibackend/gfd/application/dto/gfdTipoDocumento/GfdTipoDocumentoUpdateInputDto.java
+++ b/src/main/java/br/com/mili/milibackend/gfd/application/dto/gfdTipoDocumento/GfdTipoDocumentoUpdateInputDto.java
@@ -21,4 +21,7 @@ public class GfdTipoDocumentoUpdateInputDto {
     private Integer diasValidade;
     @NotNull
     private Boolean obrigatoriedade;
+
+    private String classificacao;
+
 }

--- a/src/main/java/br/com/mili/milibackend/gfd/application/dto/gfdTipoDocumento/GfdTipoDocumentoUpdateOutputDto.java
+++ b/src/main/java/br/com/mili/milibackend/gfd/application/dto/gfdTipoDocumento/GfdTipoDocumentoUpdateOutputDto.java
@@ -22,4 +22,7 @@ public class GfdTipoDocumentoUpdateOutputDto {
     private Boolean obrigatoriedade;
 
     private Boolean ativo;
+
+    private String classificacao;
+
 }

--- a/src/main/java/br/com/mili/milibackend/gfd/application/helpers/GfdDocumentoNavigation.java
+++ b/src/main/java/br/com/mili/milibackend/gfd/application/helpers/GfdDocumentoNavigation.java
@@ -1,0 +1,4 @@
+package br.com.mili.milibackend.gfd.application.helpers;
+
+public record GfdDocumentoNavigation(int nextDoc, int prevDoc) {
+}

--- a/src/main/java/br/com/mili/milibackend/gfd/application/helpers/GfdTipoDocumentoNavigationHelper.java
+++ b/src/main/java/br/com/mili/milibackend/gfd/application/helpers/GfdTipoDocumentoNavigationHelper.java
@@ -1,0 +1,27 @@
+package br.com.mili.milibackend.gfd.application.helpers;
+
+import br.com.mili.milibackend.gfd.application.dto.gfdTipoDocumento.GfdTipoDocumentoGetAllOutputDto;
+
+import java.util.List;
+
+public class GfdTipoDocumentoNavigationHelper {
+
+    public static GfdDocumentoNavigation calculateNavigation(List<GfdTipoDocumentoGetAllOutputDto> tipos, Integer idDocumento) {
+        var tipoDocumento = tipos.stream()
+                .filter(tipo -> tipo.getId().equals(idDocumento))
+                .findFirst();
+
+        int index = tipoDocumento.map(tipos::indexOf)
+                .orElse(-1);
+
+        if (index == -1 || tipos.isEmpty()) {
+            return new GfdDocumentoNavigation(0, 0);
+        }
+
+        boolean isLast = index == tipos.size() - 1;
+        int nextDoc = isLast ? 0 : tipos.get(index + 1).getId();
+        int prevDoc = index > 0 ? tipos.get(index - 1).getId() : 0;
+
+        return new GfdDocumentoNavigation(nextDoc, prevDoc);
+    }
+}

--- a/src/main/java/br/com/mili/milibackend/gfd/application/service/GfdDocumentoService.java
+++ b/src/main/java/br/com/mili/milibackend/gfd/application/service/GfdDocumentoService.java
@@ -21,6 +21,7 @@ import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDate;
 import java.util.List;
 
 import static br.com.mili.milibackend.gfd.adapter.exception.GfdDocumentoCodeException.GFD_DOCUMENTO_DELETE_PERMISSAO_INVALIDA;
@@ -34,117 +35,12 @@ public class GfdDocumentoService implements IGfdDocumentoService {
     private final S3ServiceImpl s3Service;
 
     @Override
-    public List<FindLatestDocumentsGroupedByTipoAndFornecedorIdOutputDto> findLatestDocumentsGroupedByTipoAndFornecedorId(Integer fornecedorId, Integer idFuncionario) {
-        var listGfdDocumento = gfdDocumentoRepository.findLatestDocumentsGroupedByTipoAndFornecedorId(fornecedorId, idFuncionario);
+    public List<FindLatestDocumentsGroupedByTipoAndFornecedorIdOutputDto> findLatestDocumentsGroupedByTipoAndFornecedorId(Integer fornecedorId, Integer idFuncionario, LocalDate periodo) {
+        var listGfdDocumento = gfdDocumentoRepository.findLatestDocumentsByPeriodoAndFornecedorOrFuncionario(fornecedorId, idFuncionario, periodo);
 
         return listGfdDocumento.stream()
                 .map(gfdDocumento ->
                         modelMapper.map(gfdDocumento, FindLatestDocumentsGroupedByTipoAndFornecedorIdOutputDto.class)).toList();
-    }
-
-    @Override
-    public MyPage<GfdDocumentoGetAllOutputDto> getAll(GfdDocumentoGetAllInputDto inputDto) {
-        Specification<GfdDocumento> spec = Specification.where(null);
-
-        //filtra por fornecedor
-        if (inputDto.getCtforCodigo() != null) {
-            spec = spec.and(GfdDocumentoSpecification.filtroPorFornecedor(inputDto.getCtforCodigo()));
-        }
-
-        //filtra por funcionario
-        spec = filtroFuncionario(inputDto, spec);
-
-
-        //filtra por nome do arquivo
-        if (inputDto.getNomeArquivo() != null) {
-            spec = spec.and(GfdDocumentoSpecification.filtroNomeArquivoContem(inputDto.getNomeArquivo()));
-        }
-
-        //filtra por status
-        if (inputDto.getStatus() != null) {
-            spec = spec.and(GfdDocumentoSpecification.filtroStatus(GfdDocumentoStatusEnum.valueOf(inputDto.getStatus())));
-        }
-
-        //filtra por tipo
-        if (inputDto.getTipoDocumentoId() != null) {
-            spec = spec.and(GfdDocumentoSpecification.filtroPorTipo(inputDto.getTipoDocumentoId()));
-        }
-
-        //filtra por range dataCadastro
-        spec = spec.and(GfdDocumentoSpecification.filtroRangeDataCadastro(inputDto.getDataCadastroInic(), inputDto.getDataCadastroFinal()));
-
-        //filtra por range dataValidade
-        spec = spec.and(GfdDocumentoSpecification.filtroRangeDataValidade(inputDto.getDataValidadeInic(), inputDto.getDataValidadeFinal()));
-
-        //filtra por range dataEmissao
-        spec = spec.and(GfdDocumentoSpecification.filtroRangeDataEmissao(inputDto.getDataEmissaoInic(), inputDto.getDataEmissaoFinal()));
-
-        //page
-        var pageNumber = inputDto.getPageable().getPage() > 0 ? inputDto.getPageable().getPage() - 1 : 0;
-        var pageSize = inputDto.getPageable().getSize() > 0 ? inputDto.getPageable().getSize() : 20;
-
-        var pageGfdDocumentos = gfdDocumentoRepository.getAll(spec, PageRequest.of(pageNumber, pageSize, Sort.by(Sort.Direction.DESC, "id")));
-
-        List<GfdDocumentoGetAllOutputDto> gfdDocumentoGetAllOutputDto = pageGfdDocumentos.getContent().stream()
-                .map(gfdDocumento -> modelMapper.map(gfdDocumento, GfdDocumentoGetAllOutputDto.class))
-                .toList();
-
-        return new PageBaseImpl<>(gfdDocumentoGetAllOutputDto, pageGfdDocumentos.getPageable().getPageNumber() + 1, pageGfdDocumentos.getSize(), pageGfdDocumentos.getTotalElements()) {
-        };
-    }
-
-    private static Specification<GfdDocumento> filtroFuncionario(GfdDocumentoGetAllInputDto inputDto, Specification<GfdDocumento> spec) {
-        var funcionario = inputDto.getFuncionario();
-
-        if (funcionario != null) {
-            if (funcionario.getId() != null) {
-                spec = spec.and(GfdDocumentoSpecification.filtroFornecedorId(funcionario.getId()));
-            }
-
-            // filtra por nome
-            if (funcionario.getNome() != null) {
-                spec = spec.and(GfdDocumentoSpecification.filtroFornecedorNome(funcionario.getNome()));
-            }
-
-            // filtra por cpf
-            if (funcionario.getCpf() != null) {
-                spec = spec.and(GfdDocumentoSpecification.filtroFornecedorCpf(funcionario.getCpf()));
-            }
-        }
-
-        return spec;
-    }
-
-    @Override
-    public GfdDocumentoUpdateOutputDto update(GfdDocumentoUpdateInputDto inputDto) {
-        GfdDocumento gfdDocumento = gfdDocumentoRepository.findById(inputDto.getId())
-                .orElseThrow(() ->
-                        new NotFoundException(GFD_DOCUMENTO_NAO_ENCONTRADO.getMensagem(), GFD_DOCUMENTO_NAO_ENCONTRADO.getCode())
-                );
-
-        modelMapper.map(inputDto, gfdDocumento);
-
-        gfdDocumento.setStatus(GfdDocumentoStatusEnum.valueOf(inputDto.getStatus()));
-
-        gfdDocumentoRepository.save(gfdDocumento);
-
-        return modelMapper.map(gfdDocumento, GfdDocumentoUpdateOutputDto.class);
-    }
-
-    @Override
-    public void delete(GfdDocumentoDeleteInputDto inputDto) {
-        var gfdDocumento = gfdDocumentoRepository.findById(inputDto.getId())
-                .orElseThrow(() ->
-                        new NotFoundException(GFD_DOCUMENTO_NAO_ENCONTRADO.getMensagem(), GFD_DOCUMENTO_NAO_ENCONTRADO.getCode())
-                );
-
-        boolean isNotStatusEnviado = !gfdDocumento.getStatus().equals(GfdDocumentoStatusEnum.ENVIADO);
-
-        if (isNotStatusEnviado) {
-            throw new NotFoundException(GFD_DOCUMENTO_DELETE_PERMISSAO_INVALIDA.getMensagem(), GFD_DOCUMENTO_DELETE_PERMISSAO_INVALIDA.getCode());
-        }
-
-        gfdDocumentoRepository.delete(gfdDocumento);
     }
 
     @Override
@@ -159,7 +55,6 @@ public class GfdDocumentoService implements IGfdDocumentoService {
 
         return new GfdDocumentoDownloadOutputDto(fornecedor.getId(), url);
     }
-
 
 
 }

--- a/src/main/java/br/com/mili/milibackend/gfd/application/service/GfdTipoDocumentoService.java
+++ b/src/main/java/br/com/mili/milibackend/gfd/application/service/GfdTipoDocumentoService.java
@@ -3,54 +3,21 @@ package br.com.mili.milibackend.gfd.application.service;
 import br.com.mili.milibackend.gfd.application.dto.gfdTipoDocumento.*;
 import br.com.mili.milibackend.gfd.domain.entity.GfdTipoDocumento;
 import br.com.mili.milibackend.gfd.domain.interfaces.IGfdTipoDocumentoService;
-import br.com.mili.milibackend.gfd.infra.specification.GfdTipoDocumentoSpecification;
 import br.com.mili.milibackend.gfd.infra.repository.GfdTipoDocumentoRepository;
 import br.com.mili.milibackend.shared.exception.types.NotFoundException;
+import lombok.RequiredArgsConstructor;
 import org.modelmapper.ModelMapper;
-import org.springframework.data.domain.Sort;
-import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Service;
-
-import java.util.List;
 
 import static br.com.mili.milibackend.gfd.adapter.exception.GfdMCodeException.GFD_TIPO_DOCUMENTO_NAO_ENCONTRADO;
 
 @Service
+@RequiredArgsConstructor
 public class GfdTipoDocumentoService implements IGfdTipoDocumentoService {
     private final GfdTipoDocumentoRepository gfdTipoDocumentoRepository;
+    private final GfdDocumentoService gfdDocumentoService;
     private final ModelMapper modelMapper;
 
-    public GfdTipoDocumentoService(GfdTipoDocumentoRepository gfdTipoDocumentoRepository, ModelMapper modelMapper) {
-        this.gfdTipoDocumentoRepository = gfdTipoDocumentoRepository;
-        this.modelMapper = modelMapper;
-    }
-
-    @Override
-    public List<GfdTipoDocumentoGetAllOutputDto> getAll(GfdTipoDocumentoGetAllInputDto inputDto) {
-        Specification<GfdTipoDocumento> spec = Specification.where(null);
-
-        //filtra por tipo
-        if (inputDto.getTipo() != null) {
-            spec = spec.and(GfdTipoDocumentoSpecification.filtroTipo(inputDto.getTipo()));
-        }
-
-        //filtra por nome
-        if (inputDto.getNome() != null) {
-            spec = spec.and(GfdTipoDocumentoSpecification.filtroNome(inputDto.getNome()));
-        }
-
-        //filtra por id
-        if (inputDto.getId() != null) {
-            spec = spec.and(GfdTipoDocumentoSpecification.filtroId(inputDto.getId()));
-        }
-
-        //filtra apenas os ativos
-        spec = spec.and(GfdTipoDocumentoSpecification.filtroAtivo(true));
-
-        var listTipoDocumento = gfdTipoDocumentoRepository.findAll(spec, Sort.by(Sort.Direction.DESC, "id"));
-
-        return listTipoDocumento.stream().map(tipoDocumento -> modelMapper.map(tipoDocumento, GfdTipoDocumentoGetAllOutputDto.class)).toList();
-    }
 
     @Override
     public GfdTipoDocumentoGetByIdOutputDto getById(Integer id) {

--- a/src/main/java/br/com/mili/milibackend/gfd/application/usecases/DocumentoPeriodo/CreateDocumentoPeriodoUseCaseImpl.java
+++ b/src/main/java/br/com/mili/milibackend/gfd/application/usecases/DocumentoPeriodo/CreateDocumentoPeriodoUseCaseImpl.java
@@ -1,0 +1,103 @@
+package br.com.mili.milibackend.gfd.application.usecases.DocumentoPeriodo;
+
+import br.com.mili.milibackend.gfd.application.dto.gfdDocumentoPeriodo.GfdDocumentoPeriodoCreateInputDto;
+import br.com.mili.milibackend.gfd.application.dto.gfdDocumentoPeriodo.GfdDocumentoPeriodoCreateOutputDto;
+import br.com.mili.milibackend.gfd.domain.entity.GfdDocumento;
+import br.com.mili.milibackend.gfd.domain.entity.GfdDocumentoPeriodo;
+import br.com.mili.milibackend.gfd.domain.usecases.CreateDocumentoPeriodoUseCase;
+import br.com.mili.milibackend.gfd.infra.repository.GfdDocumentoPeriodoRepository;
+import br.com.mili.milibackend.shared.exception.types.BadRequestException;
+import lombok.RequiredArgsConstructor;
+import org.modelmapper.ModelMapper;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+
+import static br.com.mili.milibackend.gfd.adapter.exception.GfdMCodeException.GFD_PERIODO_VAZIO;
+import static br.com.mili.milibackend.gfd.domain.entity.GfdTipoDocumentoTipoClassificacaoEnum.COMPETENCIA;
+
+@Service
+@RequiredArgsConstructor
+public class CreateDocumentoPeriodoUseCaseImpl implements CreateDocumentoPeriodoUseCase {
+    private final GfdDocumentoPeriodoRepository gfdDocumentoPeriodoRepository;
+    private final ModelMapper modelMapper;
+
+    @Override
+    public GfdDocumentoPeriodoCreateOutputDto execute(GfdDocumentoPeriodoCreateInputDto inputDto) {
+        var tipoDocumentoDto = inputDto.getTipoDocumento();
+        var gfdDocumentoPeriodoDto = inputDto.getGfdDocumentoPeriodo();
+        var gfdDocumentoDto = inputDto.getGfdDocumentoDto();
+
+        GfdDocumentoPeriodoCreateOutputDto gfdDocumentoPeriodosCreatedDto = null;
+
+        //geral
+        // cria um periodo de documento
+        // - pega o valor por tipo validade e cria os registros
+        var gfdDocumento = new GfdDocumento();
+        gfdDocumento.setId(gfdDocumentoDto.getId());
+
+        boolean isGeral = tipoDocumentoDto.getClassificacao() == null || !tipoDocumentoDto.getClassificacao().equals(COMPETENCIA.name());
+
+        if (isGeral) {
+            final int UM_MES_EN_DIAS = 30;
+
+            var diasValidade = (tipoDocumentoDto.getDiasValidade() / UM_MES_EN_DIAS);
+            int qtdPeriodos = (int) Math.ceil(diasValidade);
+
+            var primeiroPeriodo = gfdDocumentoDto.getDataEmissao().withDayOfMonth(1);
+            var ultimoPeriodo = ultimoPeriodo(inputDto, gfdDocumentoDto, qtdPeriodos);
+
+            // apaga os periodos iguais para o mesmo tipo de documento
+            // quando for update
+            if (inputDto.isUpdate()) {
+                gfdDocumentoPeriodoRepository.deleteByGfdDocumento_Id(gfdDocumentoDto.getId());
+            }
+
+            var gfdDocumentoPeriodo = GfdDocumentoPeriodo.builder()
+                    .periodoInicial(primeiroPeriodo)
+                    .periodoFinal(ultimoPeriodo)
+                    .gfdDocumento(gfdDocumento)
+                    .build();
+
+            gfdDocumentoPeriodosCreatedDto = modelMapper.map(gfdDocumentoPeriodoRepository.save(gfdDocumentoPeriodo), GfdDocumentoPeriodoCreateOutputDto.class);
+
+        } else {
+            // competencia
+            // - pega o valor por meio do input e cria os registros
+            if (gfdDocumentoPeriodoDto == null) {
+                throw new BadRequestException(GFD_PERIODO_VAZIO.getMensagem(), GFD_PERIODO_VAZIO.getCode());
+            }
+            var primeiroPeriodo = gfdDocumentoPeriodoDto.getPeriodo().withDayOfMonth(1);
+            var ultimoPeriodo = gfdDocumentoPeriodoDto.getPeriodo().withDayOfMonth(gfdDocumentoPeriodoDto.getPeriodo().lengthOfMonth());
+
+            var gfdDocumentoPeriodo = GfdDocumentoPeriodo.builder()
+                    .periodoInicial(primeiroPeriodo)
+                    .periodoFinal(ultimoPeriodo)
+                    .gfdDocumento(gfdDocumento)
+                    .build();
+
+            // apaga o periodo quando for atualização
+            if (inputDto.isUpdate()) {
+                gfdDocumentoPeriodoRepository.deleteByGfdDocumento_Id(gfdDocumentoDto.getId());
+            }
+
+            var gfdDocumentoPeriodoCreated = gfdDocumentoPeriodoRepository.save(gfdDocumentoPeriodo);
+
+            gfdDocumentoPeriodosCreatedDto = (modelMapper.map(gfdDocumentoPeriodoCreated, GfdDocumentoPeriodoCreateOutputDto.class));
+        }
+
+        return gfdDocumentoPeriodosCreatedDto;
+    }
+
+    private LocalDate ultimoPeriodo(GfdDocumentoPeriodoCreateInputDto inputDto, GfdDocumentoPeriodoCreateInputDto.GfdDocumentoDto gfdDocumentoDto, int qtdPeriodos) {
+        var ultimoPeriodo = gfdDocumentoDto.getDataEmissao()
+                .plusMonths(qtdPeriodos == 1 ? qtdPeriodos : qtdPeriodos - 1)
+                .withDayOfMonth(gfdDocumentoDto.getDataEmissao().plusMonths(qtdPeriodos).lengthOfMonth());
+
+        if (inputDto.getGfdDocumentoDto().getDataValidade() != null) {
+            ultimoPeriodo = inputDto.getGfdDocumentoDto().getDataValidade().withDayOfMonth(inputDto.getGfdDocumentoDto().getDataValidade().lengthOfMonth());
+        }
+
+        return ultimoPeriodo;
+    }
+}

--- a/src/main/java/br/com/mili/milibackend/gfd/application/usecases/GfdDocumento/CreateGfdDocumentoUseCaseImpl.java
+++ b/src/main/java/br/com/mili/milibackend/gfd/application/usecases/GfdDocumento/CreateGfdDocumentoUseCaseImpl.java
@@ -1,4 +1,4 @@
-package br.com.mili.milibackend.gfd.application.usecases;
+package br.com.mili.milibackend.gfd.application.usecases.GfdDocumento;
 
 import br.com.mili.milibackend.gfd.application.dto.gfdDocumento.GfdDocumentoCreateInputDto;
 import br.com.mili.milibackend.gfd.application.dto.gfdDocumento.GfdDocumentoCreateOutputDto;
@@ -6,8 +6,6 @@ import br.com.mili.milibackend.gfd.domain.entity.GfdDocumento;
 import br.com.mili.milibackend.gfd.domain.usecases.CreateDocumentoUseCase;
 import br.com.mili.milibackend.gfd.infra.repository.gfdDocumento.GfdDocumentoRepository;
 import br.com.mili.milibackend.shared.infra.aws.IS3Service;
-import br.com.mili.milibackend.shared.infra.aws.StorageFolderEnum;
-import br.com.mili.milibackend.shared.infra.aws.dto.AttachmentDto;
 import com.google.gson.Gson;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
@@ -16,11 +14,9 @@ import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
-public class CreateDocumentoUseCaseImpl implements CreateDocumentoUseCase {
+public class CreateGfdDocumentoUseCaseImpl implements CreateDocumentoUseCase {
     private final GfdDocumentoRepository gfdDocumentoRepository;
     private final ModelMapper modelMapper;
-    private final Gson gson;
-    private final IS3Service s3Service;
 
     @Override
     @Transactional
@@ -29,8 +25,6 @@ public class CreateDocumentoUseCaseImpl implements CreateDocumentoUseCase {
         var gfdDocumento = modelMapper.map(inputDto.getGfdDocumentoDto(), GfdDocumento.class);
 
         var gfdDocumentoCreated = gfdDocumentoRepository.save(gfdDocumento);
-
-
 
         return modelMapper.map(gfdDocumentoCreated, GfdDocumentoCreateOutputDto.class);
     }

--- a/src/main/java/br/com/mili/milibackend/gfd/application/usecases/GfdDocumento/DeleteGfdDocumentoUseCaseImpl.java
+++ b/src/main/java/br/com/mili/milibackend/gfd/application/usecases/GfdDocumento/DeleteGfdDocumentoUseCaseImpl.java
@@ -1,0 +1,42 @@
+package br.com.mili.milibackend.gfd.application.usecases.GfdDocumento;
+
+import br.com.mili.milibackend.gfd.application.dto.gfdDocumento.GfdDocumentoDeleteInputDto;
+import br.com.mili.milibackend.gfd.domain.entity.GfdDocumentoStatusEnum;
+import br.com.mili.milibackend.gfd.domain.usecases.DeleteGfdDocumentoUseCase;
+import br.com.mili.milibackend.gfd.infra.repository.GfdDocumentoPeriodoRepository;
+import br.com.mili.milibackend.gfd.infra.repository.gfdDocumento.GfdDocumentoRepository;
+import br.com.mili.milibackend.shared.exception.types.NotFoundException;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import static br.com.mili.milibackend.gfd.adapter.exception.GfdDocumentoCodeException.GFD_DOCUMENTO_DELETE_PERMISSAO_INVALIDA;
+import static br.com.mili.milibackend.gfd.adapter.exception.GfdDocumentoCodeException.GFD_DOCUMENTO_NAO_ENCONTRADO;
+
+@Service
+@RequiredArgsConstructor
+public class DeleteGfdDocumentoUseCaseImpl implements DeleteGfdDocumentoUseCase {
+    private final GfdDocumentoRepository gfdDocumentoRepository;
+    private final GfdDocumentoPeriodoRepository gfdDocumentoPeriodoRepository;
+
+    @Override
+    @Transactional
+    public void execute(GfdDocumentoDeleteInputDto inputDto) {
+        var gfdDocumento = gfdDocumentoRepository.findById(inputDto.getId())
+                .orElseThrow(() ->
+                        new NotFoundException(GFD_DOCUMENTO_NAO_ENCONTRADO.getMensagem(), GFD_DOCUMENTO_NAO_ENCONTRADO.getCode())
+                );
+
+        boolean isNotStatusEnviado = !gfdDocumento.getStatus().equals(GfdDocumentoStatusEnum.ENVIADO);
+
+        if (isNotStatusEnviado) {
+            throw new NotFoundException(GFD_DOCUMENTO_DELETE_PERMISSAO_INVALIDA.getMensagem(), GFD_DOCUMENTO_DELETE_PERMISSAO_INVALIDA.getCode());
+        }
+
+        var gfdDocumentoPeriodo = gfdDocumentoPeriodoRepository.getByGfdDocumento_Id(gfdDocumento.getId());
+
+        gfdDocumentoPeriodo.ifPresent(gfdDocumentoPeriodoRepository::delete);
+
+        gfdDocumentoRepository.delete(gfdDocumento);
+    }
+}

--- a/src/main/java/br/com/mili/milibackend/gfd/application/usecases/GfdDocumento/GetAllGfdDocumentosUseCaseImpl.java
+++ b/src/main/java/br/com/mili/milibackend/gfd/application/usecases/GfdDocumento/GetAllGfdDocumentosUseCaseImpl.java
@@ -1,0 +1,107 @@
+package br.com.mili.milibackend.gfd.application.usecases.GfdDocumento;
+
+import br.com.mili.milibackend.gfd.application.dto.gfdDocumento.GfdDocumentoGetAllInputDto;
+import br.com.mili.milibackend.gfd.application.dto.gfdDocumento.GfdDocumentoGetAllOutputDto;
+import br.com.mili.milibackend.gfd.domain.entity.GfdDocumento;
+import br.com.mili.milibackend.gfd.domain.entity.GfdDocumentoStatusEnum;
+import br.com.mili.milibackend.gfd.domain.usecases.GetAllGfdDocumentosUseCase;
+import br.com.mili.milibackend.gfd.infra.repository.gfdDocumento.GfdDocumentoRepository;
+import br.com.mili.milibackend.gfd.infra.specification.GfdDocumentoSpecification;
+import br.com.mili.milibackend.shared.page.pagination.MyPage;
+import br.com.mili.milibackend.shared.page.pagination.PageBaseImpl;
+import lombok.RequiredArgsConstructor;
+import org.modelmapper.ModelMapper;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.jpa.domain.Specification;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class GetAllGfdDocumentosUseCaseImpl implements GetAllGfdDocumentosUseCase {
+    private final GfdDocumentoRepository repository;
+    private final ModelMapper modelMapper;
+
+    @Override
+    public MyPage<GfdDocumentoGetAllOutputDto> execute(GfdDocumentoGetAllInputDto inputDto) {
+        Specification<GfdDocumento> spec = Specification.where(null);
+
+        spec = aplicarFiltros(inputDto, spec);
+
+        //page
+        var pageNumber = inputDto.getPageable().getPage() > 0 ? inputDto.getPageable().getPage() - 1 : 0;
+        var pageSize = inputDto.getPageable().getSize() > 0 ? inputDto.getPageable().getSize() : 20;
+
+        var pageGfdDocumentos = repository.getAll(spec, PageRequest.of(pageNumber, pageSize, Sort.by(Sort.Direction.DESC, "id")));
+
+        List<GfdDocumentoGetAllOutputDto> gfdDocumentoGetAllOutputDto = pageGfdDocumentos.getContent().stream()
+                .map(gfdDocumento -> modelMapper.map(gfdDocumento, GfdDocumentoGetAllOutputDto.class))
+                .toList();
+
+        return new PageBaseImpl<>(gfdDocumentoGetAllOutputDto, pageGfdDocumentos.getPageable().getPageNumber() + 1, pageGfdDocumentos.getSize(), pageGfdDocumentos.getTotalElements()) {
+        };
+    }
+
+    private static Specification<GfdDocumento> aplicarFiltros(GfdDocumentoGetAllInputDto inputDto, Specification<GfdDocumento> spec) {
+        //filtra por fornecedor
+        if (inputDto.getCtforCodigo() != null) {
+            spec = spec.and(GfdDocumentoSpecification.filtroPorFornecedor(inputDto.getCtforCodigo()));
+        }
+
+        //filtra por funcionario
+        spec = filtroFuncionario(inputDto, spec);
+
+
+        //filtra por nome do arquivo
+        if (inputDto.getNomeArquivo() != null) {
+            spec = spec.and(GfdDocumentoSpecification.filtroNomeArquivoContem(inputDto.getNomeArquivo()));
+        }
+
+        //filtra por status
+        if (inputDto.getStatus() != null) {
+            spec = spec.and(GfdDocumentoSpecification.filtroStatus(GfdDocumentoStatusEnum.valueOf(inputDto.getStatus())));
+        }
+
+        //filtra por tipo
+        if (inputDto.getTipoDocumentoId() != null) {
+            spec = spec.and(GfdDocumentoSpecification.filtroPorTipo(inputDto.getTipoDocumentoId()));
+        }
+
+        //filtra por range dataCadastro
+        spec = spec.and(GfdDocumentoSpecification.filtroRangeDataCadastro(inputDto.getDataCadastroInic(), inputDto.getDataCadastroFinal()));
+
+        //filtra por range dataValidade
+        spec = spec.and(GfdDocumentoSpecification.filtroRangeDataValidade(inputDto.getDataValidadeInic(), inputDto.getDataValidadeFinal()));
+
+        //filtra por range dataEmissao
+        spec = spec.and(GfdDocumentoSpecification.filtroRangeDataEmissao(inputDto.getDataEmissaoInic(), inputDto.getDataEmissaoFinal()));
+
+        //filtra por periodo
+        spec = spec.and(GfdDocumentoSpecification.filtroPeriodo(inputDto.getPeriodo()));
+        return spec;
+    }
+
+    private static Specification<GfdDocumento> filtroFuncionario(GfdDocumentoGetAllInputDto inputDto, Specification<GfdDocumento> spec) {
+        var funcionario = inputDto.getFuncionario();
+
+        if (funcionario != null) {
+            if (funcionario.getId() != null) {
+                spec = spec.and(GfdDocumentoSpecification.filtroFornecedorId(funcionario.getId()));
+            }
+
+            // filtra por nome
+            if (funcionario.getNome() != null) {
+                spec = spec.and(GfdDocumentoSpecification.filtroFornecedorNome(funcionario.getNome()));
+            }
+
+            // filtra por cpf
+            if (funcionario.getCpf() != null) {
+                spec = spec.and(GfdDocumentoSpecification.filtroFornecedorCpf(funcionario.getCpf()));
+            }
+        }
+
+        return spec;
+    }
+}

--- a/src/main/java/br/com/mili/milibackend/gfd/application/usecases/GfdDocumento/GetAllGfdDocumentsStatusUseCaseImpl.java
+++ b/src/main/java/br/com/mili/milibackend/gfd/application/usecases/GfdDocumento/GetAllGfdDocumentsStatusUseCaseImpl.java
@@ -1,0 +1,129 @@
+package br.com.mili.milibackend.gfd.application.usecases.GfdDocumento;
+
+import br.com.mili.milibackend.fornecedor.domain.usecases.GetFornecedorByCodOrIdUseCase;
+import br.com.mili.milibackend.gfd.application.dto.GfdMVerificarDocumentosInputDto;
+import br.com.mili.milibackend.gfd.application.dto.GfdMVerificarDocumentosOutputDto;
+import br.com.mili.milibackend.gfd.domain.entity.GfdDocumento;
+import br.com.mili.milibackend.gfd.application.dto.gfdTipoDocumento.GfdTipoDocumentoGetAllInputDto;
+import br.com.mili.milibackend.gfd.application.dto.gfdTipoDocumento.GfdTipoDocumentoGetAllOutputDto;
+import br.com.mili.milibackend.gfd.domain.entity.GfdFuncionario;
+import br.com.mili.milibackend.gfd.domain.entity.GfdFuncionarioTipoContratacaoEnum;
+import br.com.mili.milibackend.gfd.domain.entity.GfdTipoDocumentoTipoEnum;
+import br.com.mili.milibackend.gfd.domain.usecases.GetAllGfdDocumentsStatusUseCase;
+import br.com.mili.milibackend.gfd.domain.usecases.GetAllTipoDocumentoUseCase;
+import br.com.mili.milibackend.gfd.infra.repository.gfdDocumento.GfdDocumentoRepository;
+import br.com.mili.milibackend.gfd.infra.repository.gfdFuncionario.GfdFuncionarioRepository;
+import br.com.mili.milibackend.shared.exception.types.NotFoundException;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+import static br.com.mili.milibackend.gfd.adapter.exception.GfdFuncionarioCodeException.GFD_FUNCIONARIO_NAO_ENCONTRADO;
+
+@RequiredArgsConstructor
+@Service
+public class GetAllGfdDocumentsStatusUseCaseImpl implements GetAllGfdDocumentsStatusUseCase {
+    private final GetFornecedorByCodOrIdUseCase getFornecedorByCodOrIdUseCase;
+    private final GfdFuncionarioRepository gfdFuncionarioRepository;
+    private final GetAllTipoDocumentoUseCase getAllTipoDocumentoUseCase;
+    private final GfdDocumentoRepository gfdDocumentoRepository;
+
+    @Override
+    public GfdMVerificarDocumentosOutputDto execute(@Valid GfdMVerificarDocumentosInputDto inputDto) {
+        var output = new GfdMVerificarDocumentosOutputDto();
+        var documentos = new LinkedHashSet<GfdMVerificarDocumentosOutputDto.DocumentoDto>();
+
+        var fornecedor = getFornecedorByCodOrIdUseCase.execute(inputDto.getCodUsuario(), inputDto.getId());
+
+        // adiciona no title o nome do fornecedor
+        output.setTitle(fornecedor.getRazaoSocial());
+
+        /* Aqui pegamos todos os documentos recentes do fornecedor ou funcionario,
+        de cada tipo, para podermos exibir os status na tela*/
+        var latestDocuments = gfdDocumentoRepository.findLatestDocumentsByPeriodoAndFornecedorOrFuncionario(fornecedor.getCodigo(), inputDto.getIdFuncionario(), inputDto.getPeriodo());
+
+        /* extrair */
+        var tipoDocumentoInputDto = new GfdTipoDocumentoGetAllInputDto();
+        tipoDocumentoInputDto.setTipo(GfdTipoDocumentoTipoEnum.FORNECEDOR);
+
+        if (inputDto.getIdFuncionario() != null) {
+            // pega as informacoes de funcionario
+            var funcionario = getGfdFuncionarioGetByIdOutputDto(inputDto.getIdFuncionario());
+
+            // adiciona no title o nome do funcionario
+            output.setTitle(fornecedor.getRazaoSocial() + " - " + funcionario.getNome());
+
+            if (funcionario.getTipoContratacao().equals(GfdFuncionarioTipoContratacaoEnum.CLT.getDescricao())) {
+                tipoDocumentoInputDto.setTipo(GfdTipoDocumentoTipoEnum.FUNCIONARIO_CLT);
+            } else if (funcionario.getTipoContratacao().equals(GfdFuncionarioTipoContratacaoEnum.CLT_SEGURANCA.getDescricao())) {
+                tipoDocumentoInputDto.setTipo(GfdTipoDocumentoTipoEnum.FUNCIONARIO_CLT_SEGURANCA);
+            } else {
+                tipoDocumentoInputDto.setTipo(GfdTipoDocumentoTipoEnum.FUNCIONARIO_MEI);
+            }
+        }
+        /**/
+
+        var tipoDocumentos = getAllTipoDocumentoUseCase.execute(tipoDocumentoInputDto);
+
+        addNonMandatoryDocuments(documentos, latestDocuments, tipoDocumentos);
+        addMandatoryDocuments(documentos, latestDocuments, tipoDocumentos);
+
+        output.setDocumentos(documentos.stream().toList());
+
+        return output;
+    }
+
+    private GfdFuncionario getGfdFuncionarioGetByIdOutputDto(Integer inputDto) {
+        return gfdFuncionarioRepository.findById(inputDto).orElseThrow(
+                () -> new NotFoundException(GFD_FUNCIONARIO_NAO_ENCONTRADO.getMensagem(), GFD_FUNCIONARIO_NAO_ENCONTRADO.getCode()
+                ));
+    }
+
+    private void addNonMandatoryDocuments
+            (Set<GfdMVerificarDocumentosOutputDto.DocumentoDto> outputDtoList, List<GfdDocumento> listDocumento, List<GfdTipoDocumentoGetAllOutputDto> tipoDocumentos) {
+        tipoDocumentos.stream().filter(tipoDoc -> !tipoDoc.getObrigatoriedade()).forEach(tipoDoc -> {
+            var outputDto = buildGfdMVerificarDocumentoOutpDto("OPCIONAL", tipoDoc.getNome(), tipoDoc.getId());
+            outputDtoList.add(outputDto);
+        });
+    }
+
+    private void addMandatoryDocuments
+            (Set<GfdMVerificarDocumentosOutputDto.DocumentoDto> outputDtoList, List<GfdDocumento> documentos, List<GfdTipoDocumentoGetAllOutputDto> tipoDocumentos) {
+        tipoDocumentos.stream().filter(GfdTipoDocumentoGetAllOutputDto::getObrigatoriedade).forEach(tipoDoc -> {
+            if (fornecedorHasDocument(documentos, tipoDoc)) {
+                addExistingDocument(outputDtoList, documentos, tipoDoc);
+            } else {
+                var outputDto = buildGfdMVerificarDocumentoOutpDto("NÃO ENVIADO", tipoDoc.getNome(), tipoDoc.getId());
+                outputDtoList.add(outputDto);
+            }
+        });
+    }
+
+    private void addExistingDocument
+            (Set<GfdMVerificarDocumentosOutputDto.DocumentoDto> outputDtoList, List<GfdDocumento> documentos, GfdTipoDocumentoGetAllOutputDto
+                    tipoDoc) {
+        documentos.stream().filter(doc -> doc.getGfdTipoDocumento().getId().equals(tipoDoc.getId())).forEach(doc -> {
+            var outputDto = buildGfdMVerificarDocumentoOutpDto(doc.getStatus().getDescricao(), tipoDoc.getNome(), tipoDoc.getId());
+            outputDtoList.add(outputDto);
+        });
+    }
+
+    private boolean fornecedorHasDocument
+            (List<GfdDocumento> documentos, GfdTipoDocumentoGetAllOutputDto
+                    tipoDoc) {
+        return documentos.stream().anyMatch(doc -> doc.getGfdTipoDocumento().getId().equals(tipoDoc.getId()));
+    }
+
+    private GfdMVerificarDocumentosOutputDto.DocumentoDto buildGfdMVerificarDocumentoOutpDto(String status, String
+            nome, Integer idTipoDocumento) {
+        var outputDto = new GfdMVerificarDocumentosOutputDto.DocumentoDto();
+        outputDto.setStatus(status);
+        outputDto.setNome(nome);
+        outputDto.setIdTipoDocumento(idTipoDocumento);
+        return outputDto;
+    }
+}

--- a/src/main/java/br/com/mili/milibackend/gfd/application/usecases/GfdDocumento/GetAllSupplierDocumentsUseCaseImpl.java
+++ b/src/main/java/br/com/mili/milibackend/gfd/application/usecases/GfdDocumento/GetAllSupplierDocumentsUseCaseImpl.java
@@ -1,0 +1,149 @@
+package br.com.mili.milibackend.gfd.application.usecases.GfdDocumento;
+
+import br.com.mili.milibackend.fornecedor.domain.entity.Fornecedor;
+import br.com.mili.milibackend.fornecedor.domain.usecases.GetFornecedorByCodOrIdUseCase;
+import br.com.mili.milibackend.gfd.application.dto.GfdMDocumentosGetAllInputDto;
+import br.com.mili.milibackend.gfd.application.dto.GfdMDocumentosGetAllOutputDto;
+import br.com.mili.milibackend.gfd.application.dto.gfdDocumento.GfdDocumentoGetAllInputDto;
+import br.com.mili.milibackend.gfd.application.dto.gfdTipoDocumento.GfdTipoDocumentoGetAllInputDto;
+import br.com.mili.milibackend.gfd.application.dto.gfdTipoDocumento.GfdTipoDocumentoGetAllOutputDto;
+import br.com.mili.milibackend.gfd.application.helpers.GfdTipoDocumentoNavigationHelper;
+import br.com.mili.milibackend.gfd.domain.entity.*;
+import br.com.mili.milibackend.gfd.domain.usecases.GetAllGfdDocumentosUseCase;
+import br.com.mili.milibackend.gfd.domain.usecases.GetAllSupplierDocumentsUseCase;
+import br.com.mili.milibackend.gfd.domain.usecases.GetAllTipoDocumentoUseCase;
+import br.com.mili.milibackend.gfd.infra.repository.GfdDocumentoPeriodoRepository;
+import br.com.mili.milibackend.gfd.infra.repository.GfdTipoDocumentoRepository;
+import br.com.mili.milibackend.gfd.infra.repository.gfdFuncionario.GfdFuncionarioRepository;
+import br.com.mili.milibackend.shared.exception.types.NotFoundException;
+import br.com.mili.milibackend.shared.page.pagination.PageBaseImpl;
+import br.com.mili.milibackend.shared.util.CleanFileName;
+import lombok.RequiredArgsConstructor;
+import org.modelmapper.ModelMapper;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static br.com.mili.milibackend.gfd.adapter.exception.GfdFuncionarioCodeException.GFD_FUNCIONARIO_NAO_ENCONTRADO;
+import static br.com.mili.milibackend.gfd.adapter.exception.GfdMCodeException.GFD_TIPO_DOCUMENTO_NAO_ENCONTRADO;
+
+@Service
+@RequiredArgsConstructor
+public class GetAllSupplierDocumentsUseCaseImpl implements GetAllSupplierDocumentsUseCase {
+    private final GfdFuncionarioRepository funcionarioRepository;
+    private final GfdDocumentoPeriodoRepository gfdDocumentoPeriodoRepository;
+    private final GfdTipoDocumentoRepository gfdTipoDocumentoRepository;
+    private final GetAllGfdDocumentosUseCase getAllGfdDocumentosUseCase;
+    private final GetAllTipoDocumentoUseCase getAllTipoDocumentoUseCase;
+    private final ModelMapper modelMapper;
+    private final GetFornecedorByCodOrIdUseCase getFornecedorByCodOrIdUseCase;
+
+
+    @Override
+    public GfdMDocumentosGetAllOutputDto execute(GfdMDocumentosGetAllInputDto inputDto) {
+        var fornecedor = getFornecedorByCodOrIdUseCase.execute(inputDto.getCodUsuario(), inputDto.getId());
+
+        var tipoDocumento = recuperarTipoDocumento(inputDto);
+
+        var pageDocumentos = recuperarDocumentos(inputDto, fornecedor);
+
+        var recuperarTiposDocumentoFornecedor = getFornecedorTipoDocumentos(inputDto.getFuncionario() != null ? inputDto.getFuncionario().getId() : null);
+
+        var navigation = GfdTipoDocumentoNavigationHelper.calculateNavigation(recuperarTiposDocumentoFornecedor, inputDto.getTipoDocumentoId());
+
+        // adicionar na dto o periodo caso seja tipo documento competencia
+        adicionarPeriodoDeDocumentoCompetencia(tipoDocumento, pageDocumentos);
+
+        // adiciona os tipos documento
+        var gfdTipoDocumentoDto = criarDtoTipoDocumentoParaResposta(tipoDocumento);
+
+        return GfdMDocumentosGetAllOutputDto.builder().gfdTipoDocumento(gfdTipoDocumentoDto).gfdDocumento(pageDocumentos).nextDoc(navigation.nextDoc()).previousDoc(navigation.prevDoc()).build();
+    }
+
+    private void adicionarPeriodoDeDocumentoCompetencia(GfdTipoDocumento tipoDocumento, PageBaseImpl<GfdMDocumentosGetAllOutputDto.GfdDocumentoDto> pageDocumentos) {
+        if (tipoDocumento.getClassificacao() != null && tipoDocumento.getClassificacao().equals(GfdTipoDocumentoTipoClassificacaoEnum.COMPETENCIA.name())) {
+            var ids = pageDocumentos.getContent().stream().map(GfdMDocumentosGetAllOutputDto.GfdDocumentoDto::getId).toList();
+
+            var periodos = gfdDocumentoPeriodoRepository.findByGfdDocumento_IdIn(ids);
+
+            pageDocumentos.getContent().forEach(documento -> periodos.stream()
+                    .filter(gfdPeriodo -> gfdPeriodo.getGfdDocumento().getId().equals(documento.getId()))
+                    .findFirst()
+                    .ifPresent(periodo -> {
+                        var gfdDocumentoPeriodoDto = new GfdMDocumentosGetAllOutputDto.GfdDocumentoDto.GfdDocumentoPeriodoDto();
+                        gfdDocumentoPeriodoDto.setPeriodo(periodo.getPeriodoFinal());
+                        gfdDocumentoPeriodoDto.setId(periodo.getId());
+
+                        documento.setGfdDocumentoPeriodo(gfdDocumentoPeriodoDto);
+                    }));
+        }
+    }
+
+    private PageBaseImpl<GfdMDocumentosGetAllOutputDto.GfdDocumentoDto> recuperarDocumentos(GfdMDocumentosGetAllInputDto inputDto, Fornecedor fornecedor) {
+        var gfdDocumentoGetAllInputDto = modelMapper.map(inputDto, GfdDocumentoGetAllInputDto.class);
+        gfdDocumentoGetAllInputDto.setCtforCodigo(fornecedor.getCodigo());
+
+        var periodo = gfdDocumentoGetAllInputDto.getPeriodo();
+        var dataAtual = LocalDate.now().withDayOfMonth(1);
+
+        if (periodo != null && periodo.withDayOfMonth(1).equals(dataAtual)) {
+            gfdDocumentoGetAllInputDto.setPeriodo(null);
+        }
+
+        var pageGfdDocumentoService = getAllGfdDocumentosUseCase.execute(gfdDocumentoGetAllInputDto);
+
+        var gfdDocumentoDto = pageGfdDocumentoService.getContent().stream().map(gfdDocumento -> {
+            gfdDocumento.setNomeArquivo(CleanFileName.clear(gfdDocumento.getNomeArquivo()));
+            return modelMapper.map(gfdDocumento, GfdMDocumentosGetAllOutputDto.GfdDocumentoDto.class);
+        }).toList();
+
+        return new PageBaseImpl<>(gfdDocumentoDto, pageGfdDocumentoService.getPage(), pageGfdDocumentoService.getSize(), pageGfdDocumentoService.getTotalElements()) {
+        };
+    }
+
+    private GfdTipoDocumento recuperarTipoDocumento(GfdMDocumentosGetAllInputDto inputDto) {
+        return gfdTipoDocumentoRepository.findById(inputDto.getTipoDocumentoId()).orElseThrow(() ->
+                new NotFoundException(
+                        GFD_TIPO_DOCUMENTO_NAO_ENCONTRADO.getMensagem(),
+                        GFD_TIPO_DOCUMENTO_NAO_ENCONTRADO.getCode()
+                )
+        );
+    }
+
+    private GfdMDocumentosGetAllOutputDto.GfdTipoDocumentoDto criarDtoTipoDocumentoParaResposta
+            (GfdTipoDocumento tipoDocumento) {
+        var gfdTipoDocumentoDto = new GfdMDocumentosGetAllOutputDto.GfdTipoDocumentoDto();
+
+        gfdTipoDocumentoDto.setId(tipoDocumento.getId());
+        gfdTipoDocumentoDto.setNome(tipoDocumento.getNome());
+        gfdTipoDocumentoDto.setDiasValidade(tipoDocumento.getDiasValidade());
+        gfdTipoDocumentoDto.setClassificacao(tipoDocumento.getClassificacao());
+
+        return gfdTipoDocumentoDto;
+    }
+
+    List<GfdTipoDocumentoGetAllOutputDto> getFornecedorTipoDocumentos(Integer funcionarioId) {
+        var tipoDocumentoInputDto = new GfdTipoDocumentoGetAllInputDto();
+        tipoDocumentoInputDto.setTipo(GfdTipoDocumentoTipoEnum.FORNECEDOR);
+
+        if (funcionarioId != null) {
+            // pega as informacoes de funcionario
+            var funcionario = getGfdFuncionarioGetByIdOutputDto(funcionarioId);
+
+            if (funcionario.getTipoContratacao().equals(GfdFuncionarioTipoContratacaoEnum.CLT.getDescricao())) {
+                tipoDocumentoInputDto.setTipo(GfdTipoDocumentoTipoEnum.FUNCIONARIO_CLT);
+            } else {
+                tipoDocumentoInputDto.setTipo(GfdTipoDocumentoTipoEnum.FUNCIONARIO_MEI);
+            }
+        }
+
+        return getAllTipoDocumentoUseCase.execute(tipoDocumentoInputDto);
+    }
+
+    private GfdFuncionario getGfdFuncionarioGetByIdOutputDto(Integer inputDto) {
+        return funcionarioRepository.findById(inputDto).orElseThrow(
+                () -> new NotFoundException(GFD_FUNCIONARIO_NAO_ENCONTRADO.getMensagem(), GFD_FUNCIONARIO_NAO_ENCONTRADO.getCode()
+                ));
+    }
+}

--- a/src/main/java/br/com/mili/milibackend/gfd/application/usecases/GfdDocumento/UpdateGfdDocumentoUseCaseImpl.java
+++ b/src/main/java/br/com/mili/milibackend/gfd/application/usecases/GfdDocumento/UpdateGfdDocumentoUseCaseImpl.java
@@ -1,0 +1,61 @@
+package br.com.mili.milibackend.gfd.application.usecases.GfdDocumento;
+
+import br.com.mili.milibackend.gfd.application.dto.gfdDocumento.GfdDocumentoUpdateInputDto;
+import br.com.mili.milibackend.gfd.application.dto.gfdDocumento.GfdDocumentoUpdateOutputDto;
+import br.com.mili.milibackend.gfd.application.dto.gfdDocumentoPeriodo.GfdDocumentoPeriodoCreateInputDto;
+import br.com.mili.milibackend.gfd.domain.entity.GfdDocumento;
+import br.com.mili.milibackend.gfd.domain.entity.GfdDocumentoStatusEnum;
+import br.com.mili.milibackend.gfd.domain.usecases.CreateDocumentoPeriodoUseCase;
+import br.com.mili.milibackend.gfd.domain.usecases.UpdateGfdDocumentoUseCase;
+import br.com.mili.milibackend.gfd.infra.repository.gfdDocumento.GfdDocumentoRepository;
+import br.com.mili.milibackend.shared.exception.types.NotFoundException;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.modelmapper.ModelMapper;
+import org.springframework.stereotype.Service;
+
+import static br.com.mili.milibackend.gfd.adapter.exception.GfdDocumentoCodeException.GFD_DOCUMENTO_NAO_ENCONTRADO;
+
+@Service
+@RequiredArgsConstructor
+public class UpdateGfdDocumentoUseCaseImpl implements UpdateGfdDocumentoUseCase {
+    private final GfdDocumentoRepository gfdDocumentoRepository;
+    private final CreateDocumentoPeriodoUseCase createDocumentoPeriodoUseCase;
+    private final ModelMapper modelMapper;
+
+    @Override
+    @Transactional
+    public GfdDocumentoUpdateOutputDto execute(GfdDocumentoUpdateInputDto inputDto) {
+        var gfdDocumentoDto = inputDto.getGfdDocumentoDto();
+
+        GfdDocumento gfdDocumento = gfdDocumentoRepository.findById(gfdDocumentoDto.getId())
+                .orElseThrow(() ->
+                        new NotFoundException(GFD_DOCUMENTO_NAO_ENCONTRADO.getMensagem(), GFD_DOCUMENTO_NAO_ENCONTRADO.getCode())
+                );
+
+        modelMapper.map(inputDto.getGfdDocumentoDto(), gfdDocumento);
+
+        createPeriodo(gfdDocumentoDto, gfdDocumento, inputDto.getGfdDocumentoPeriodo());
+
+        gfdDocumento.setStatus(GfdDocumentoStatusEnum.valueOf(gfdDocumentoDto.getStatus()));
+
+        gfdDocumentoRepository.save(gfdDocumento);
+
+        return modelMapper.map(gfdDocumento, GfdDocumentoUpdateOutputDto.class);
+    }
+
+    private void createPeriodo(
+            GfdDocumentoUpdateInputDto.GfdDocumentoDto gfdDocumentoDto,
+            GfdDocumento gfdDocumento,
+            GfdDocumentoUpdateInputDto.GfdDocumentoPeriodoDto gfdDocumentoPeriodoDto
+    ) {
+        var periodoCreateInputDto = GfdDocumentoPeriodoCreateInputDto.builder()
+                .periodo(gfdDocumentoPeriodoDto != null ? gfdDocumentoPeriodoDto.getPeriodo() : null)
+                .documento(gfdDocumento.getId(), gfdDocumentoDto.getDataEmissao(), gfdDocumento.getDataValidade())
+                .tipoDocumento(gfdDocumento.getId(), gfdDocumento.getGfdTipoDocumento().getClassificacao(), gfdDocumento.getGfdTipoDocumento().getDiasValidade())
+                .update()
+                .build();
+
+        createDocumentoPeriodoUseCase.execute(periodoCreateInputDto);
+    }
+}

--- a/src/main/java/br/com/mili/milibackend/gfd/application/usecases/GfdDocumento/UpdateStatusObservacaoDocumentoUseCaseImpl.java
+++ b/src/main/java/br/com/mili/milibackend/gfd/application/usecases/GfdDocumento/UpdateStatusObservacaoDocumentoUseCaseImpl.java
@@ -1,4 +1,4 @@
-package br.com.mili.milibackend.gfd.application.usecases;
+package br.com.mili.milibackend.gfd.application.usecases.GfdDocumento;
 
 import br.com.mili.milibackend.gfd.adapter.exception.GfdDocumentoCodeException;
 import br.com.mili.milibackend.gfd.application.dto.gfdDocumento.GfdDocumentoUpdateStatusObservacaoInputDto;

--- a/src/main/java/br/com/mili/milibackend/gfd/application/usecases/GfdFuncionario/GetAllGfdFuncionarioUseCaseImpl.java
+++ b/src/main/java/br/com/mili/milibackend/gfd/application/usecases/GfdFuncionario/GetAllGfdFuncionarioUseCaseImpl.java
@@ -1,4 +1,4 @@
-package br.com.mili.milibackend.gfd.application.usecases;
+package br.com.mili.milibackend.gfd.application.usecases.GfdFuncionario;
 
 import br.com.mili.milibackend.gfd.application.dto.gfdFuncionario.GfdFuncionarioGetAllInputDto;
 import br.com.mili.milibackend.gfd.application.dto.gfdFuncionario.GfdFuncionarioGetAllOutputDto;

--- a/src/main/java/br/com/mili/milibackend/gfd/application/usecases/GfdFuncionario/LiberarFuncionarioUseCaseImpl.java
+++ b/src/main/java/br/com/mili/milibackend/gfd/application/usecases/GfdFuncionario/LiberarFuncionarioUseCaseImpl.java
@@ -1,4 +1,4 @@
-package br.com.mili.milibackend.gfd.application.usecases;
+package br.com.mili.milibackend.gfd.application.usecases.GfdFuncionario;
 
 import br.com.mili.milibackend.gfd.adapter.exception.GfdFuncionarioCodeException;
 import br.com.mili.milibackend.gfd.application.dto.gfdFuncionario.GfdFuncionarioLiberarInputDto;
@@ -21,7 +21,6 @@ import java.time.LocalDateTime;
 public class LiberarFuncionarioUseCaseImpl implements LiberarFuncionarioUseCase {
     private final GfdFuncionarioRepository gfdFuncionarioRepository;
     private final GfdFuncionarioLiberacaoRepository gfdFuncionarioLiberacaoRepository;
-    private final GetAllGfdFuncionarioUseCase getAllGfdFuncionarioUseCase;
     private final ModelMapper modelMapper;
 
     @Override

--- a/src/main/java/br/com/mili/milibackend/gfd/application/usecases/GfdFuncionario/UpdateObservacaoFuncionarioUseCaseImpl.java
+++ b/src/main/java/br/com/mili/milibackend/gfd/application/usecases/GfdFuncionario/UpdateObservacaoFuncionarioUseCaseImpl.java
@@ -1,4 +1,4 @@
-package br.com.mili.milibackend.gfd.application.usecases;
+package br.com.mili.milibackend.gfd.application.usecases.GfdFuncionario;
 
 import br.com.mili.milibackend.gfd.adapter.exception.GfdFuncionarioCodeException;
 import br.com.mili.milibackend.gfd.application.dto.gfdFuncionario.GfdFuncionarioUpdateObservacaoInputDto;

--- a/src/main/java/br/com/mili/milibackend/gfd/application/usecases/GfdTipoDocumento/GetAllTipoDocumentoUseCaseImpl.java
+++ b/src/main/java/br/com/mili/milibackend/gfd/application/usecases/GfdTipoDocumento/GetAllTipoDocumentoUseCaseImpl.java
@@ -1,0 +1,49 @@
+package br.com.mili.milibackend.gfd.application.usecases.GfdTipoDocumento;
+
+import br.com.mili.milibackend.gfd.application.dto.gfdTipoDocumento.GfdTipoDocumentoGetAllInputDto;
+import br.com.mili.milibackend.gfd.application.dto.gfdTipoDocumento.GfdTipoDocumentoGetAllOutputDto;
+import br.com.mili.milibackend.gfd.domain.entity.GfdTipoDocumento;
+import br.com.mili.milibackend.gfd.domain.usecases.GetAllTipoDocumentoUseCase;
+import br.com.mili.milibackend.gfd.infra.repository.GfdTipoDocumentoRepository;
+import br.com.mili.milibackend.gfd.infra.specification.GfdTipoDocumentoSpecification;
+import lombok.RequiredArgsConstructor;
+import org.modelmapper.ModelMapper;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.jpa.domain.Specification;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@Service
+public class GetAllTipoDocumentoUseCaseImpl implements GetAllTipoDocumentoUseCase {
+    private final GfdTipoDocumentoRepository gfdTipoDocumentoRepository;
+    private final ModelMapper modelMapper;
+
+    @Override
+    public List<GfdTipoDocumentoGetAllOutputDto> execute(GfdTipoDocumentoGetAllInputDto inputDto) {
+        Specification<GfdTipoDocumento> spec = Specification.where(null);
+
+        //filtra por tipo
+        if (inputDto.getTipo() != null) {
+            spec = spec.and(GfdTipoDocumentoSpecification.filtroTipo(inputDto.getTipo()));
+        }
+
+        //filtra por nome
+        if (inputDto.getNome() != null) {
+            spec = spec.and(GfdTipoDocumentoSpecification.filtroNome(inputDto.getNome()));
+        }
+
+        //filtra por id
+        if (inputDto.getId() != null) {
+            spec = spec.and(GfdTipoDocumentoSpecification.filtroId(inputDto.getId()));
+        }
+
+        //filtra apenas os ativos
+        spec = spec.and(GfdTipoDocumentoSpecification.filtroAtivo(true));
+
+        var listTipoDocumento = gfdTipoDocumentoRepository.findAll(spec, Sort.by(Sort.Direction.DESC, "id"));
+
+        return listTipoDocumento.stream().map(tipoDocumento -> modelMapper.map(tipoDocumento, GfdTipoDocumentoGetAllOutputDto.class)).toList();
+    }
+}

--- a/src/main/java/br/com/mili/milibackend/gfd/domain/entity/GfdDocumento.java
+++ b/src/main/java/br/com/mili/milibackend/gfd/domain/entity/GfdDocumento.java
@@ -73,4 +73,7 @@ public class GfdDocumento {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "ID_FUNCIONARIO")
     private GfdFuncionario gfdFuncionario;
+
+    @OneToOne(mappedBy = "gfdDocumento")
+    private GfdDocumentoPeriodo gfdDocumentoPeriodo;
 }

--- a/src/main/java/br/com/mili/milibackend/gfd/domain/entity/GfdDocumentoPeriodo.java
+++ b/src/main/java/br/com/mili/milibackend/gfd/domain/entity/GfdDocumentoPeriodo.java
@@ -1,0 +1,30 @@
+package br.com.mili.milibackend.gfd.domain.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDate;
+
+@Entity
+@Table(name = "GFD_DOCUMENTO_PERIODO")
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Setter
+@Builder
+public class GfdDocumentoPeriodo {
+    @Id
+    @SequenceGenerator(name = "SEQ_GFD_DOCUMENTO_PERIODO", sequenceName = "SEQ_GFD_DOCUMENTO_PERIODO", allocationSize = 1)
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "SEQ_GFD_DOCUMENTO_PERIODO")
+    private Integer id;
+
+    @OneToOne
+    @JoinColumn(name = "ID_DOCUMENTO")
+    private GfdDocumento gfdDocumento;
+
+    @Column(name = "PERIODO_INICIAL")
+    private LocalDate periodoInicial;
+
+    @Column(name = "PERIODO_FINAL")
+    private LocalDate periodoFinal;
+}

--- a/src/main/java/br/com/mili/milibackend/gfd/domain/entity/GfdTipoDocumento.java
+++ b/src/main/java/br/com/mili/milibackend/gfd/domain/entity/GfdTipoDocumento.java
@@ -35,4 +35,7 @@ public class GfdTipoDocumento {
 
     @Column(name = "ATIVO")
     private Boolean ativo;
+
+    @Column(name = "CLASSIFICACAO")
+    private String classificacao;
 }

--- a/src/main/java/br/com/mili/milibackend/gfd/domain/entity/GfdTipoDocumentoTipoClassificacaoEnum.java
+++ b/src/main/java/br/com/mili/milibackend/gfd/domain/entity/GfdTipoDocumentoTipoClassificacaoEnum.java
@@ -1,0 +1,5 @@
+package br.com.mili.milibackend.gfd.domain.entity;
+
+public enum GfdTipoDocumentoTipoClassificacaoEnum {
+    COMPETENCIA,
+}

--- a/src/main/java/br/com/mili/milibackend/gfd/domain/interfaces/IGfdDocumentoService.java
+++ b/src/main/java/br/com/mili/milibackend/gfd/domain/interfaces/IGfdDocumentoService.java
@@ -3,12 +3,10 @@ package br.com.mili.milibackend.gfd.domain.interfaces;
 import br.com.mili.milibackend.gfd.application.dto.gfdDocumento.*;
 import br.com.mili.milibackend.shared.page.pagination.MyPage;
 
+import java.time.LocalDate;
 import java.util.List;
 
 public interface IGfdDocumentoService {
-    MyPage<GfdDocumentoGetAllOutputDto> getAll(GfdDocumentoGetAllInputDto inputDto);
-    GfdDocumentoUpdateOutputDto update (GfdDocumentoUpdateInputDto inputDto);
-    void delete (GfdDocumentoDeleteInputDto inputDto);
+    List<FindLatestDocumentsGroupedByTipoAndFornecedorIdOutputDto> findLatestDocumentsGroupedByTipoAndFornecedorId(Integer fornecedorId, Integer idFuncionario, LocalDate periodo);
     GfdDocumentoDownloadOutputDto download(GfdDocumentoDownloadInputDto inputDto);
-    List<FindLatestDocumentsGroupedByTipoAndFornecedorIdOutputDto> findLatestDocumentsGroupedByTipoAndFornecedorId(Integer fornecedorId, Integer idFuncionario);
 }

--- a/src/main/java/br/com/mili/milibackend/gfd/domain/interfaces/IGfdManagerService.java
+++ b/src/main/java/br/com/mili/milibackend/gfd/domain/interfaces/IGfdManagerService.java
@@ -6,11 +6,7 @@ import br.com.mili.milibackend.gfd.application.dto.gfdTipoDocumento.*;
 public interface IGfdManagerService {
     GfdMVerificarFornecedorOutputDto verifyFornecedor(GfdMVerificarFornecedorInputDto inputDto);
 
-    GfdMVerificarDocumentosOutputDto verifyDocumentos(GfdMVerificarDocumentosInputDto inputDto);
-
     GfdMFornecedorGetOutputDto getFornecedor(GfdMFornecedorGetInputDto inputDto);
-
-    GfdMDocumentosGetAllOutputDto getAllDocumentos(GfdMDocumentosGetAllInputDto inputDto);
 
     GfdMFuncionarioGetAllOutputDto getAllFuncionarios(GfdMFuncionarioGetAllInputDto inputDto);
 

--- a/src/main/java/br/com/mili/milibackend/gfd/domain/interfaces/IGfdTipoDocumentoService.java
+++ b/src/main/java/br/com/mili/milibackend/gfd/domain/interfaces/IGfdTipoDocumentoService.java
@@ -5,7 +5,6 @@ import br.com.mili.milibackend.gfd.application.dto.gfdTipoDocumento.*;
 import java.util.List;
 
 public interface IGfdTipoDocumentoService {
-    List<GfdTipoDocumentoGetAllOutputDto> getAll(GfdTipoDocumentoGetAllInputDto inputDto) ;
     GfdTipoDocumentoGetByIdOutputDto getById(Integer id);
     void delete(Integer id);
     GfdTipoDocumentoCreateOutputDto create(GfdTipoDocumentoCreateInputDto inputDto);

--- a/src/main/java/br/com/mili/milibackend/gfd/domain/usecases/CreateDocumentoPeriodoUseCase.java
+++ b/src/main/java/br/com/mili/milibackend/gfd/domain/usecases/CreateDocumentoPeriodoUseCase.java
@@ -1,0 +1,11 @@
+package br.com.mili.milibackend.gfd.domain.usecases;
+
+import br.com.mili.milibackend.gfd.application.dto.gfdDocumentoPeriodo.GfdDocumentoPeriodoCreateInputDto;
+import br.com.mili.milibackend.gfd.application.dto.gfdDocumentoPeriodo.GfdDocumentoPeriodoCreateOutputDto;
+
+import java.util.List;
+
+public interface CreateDocumentoPeriodoUseCase {
+    GfdDocumentoPeriodoCreateOutputDto execute(GfdDocumentoPeriodoCreateInputDto inputDto);
+
+}

--- a/src/main/java/br/com/mili/milibackend/gfd/domain/usecases/DeleteGfdDocumentoUseCase.java
+++ b/src/main/java/br/com/mili/milibackend/gfd/domain/usecases/DeleteGfdDocumentoUseCase.java
@@ -1,0 +1,7 @@
+package br.com.mili.milibackend.gfd.domain.usecases;
+
+import br.com.mili.milibackend.gfd.application.dto.gfdDocumento.GfdDocumentoDeleteInputDto;
+
+public interface DeleteGfdDocumentoUseCase {
+    void execute(GfdDocumentoDeleteInputDto inputDto);
+}

--- a/src/main/java/br/com/mili/milibackend/gfd/domain/usecases/GetAllGfdDocumentosUseCase.java
+++ b/src/main/java/br/com/mili/milibackend/gfd/domain/usecases/GetAllGfdDocumentosUseCase.java
@@ -1,0 +1,10 @@
+package br.com.mili.milibackend.gfd.domain.usecases;
+
+
+import br.com.mili.milibackend.gfd.application.dto.gfdDocumento.GfdDocumentoGetAllInputDto;
+import br.com.mili.milibackend.gfd.application.dto.gfdDocumento.GfdDocumentoGetAllOutputDto;
+import br.com.mili.milibackend.shared.page.pagination.MyPage;
+
+public interface GetAllGfdDocumentosUseCase {
+    MyPage<GfdDocumentoGetAllOutputDto> execute(GfdDocumentoGetAllInputDto inputDto);
+}

--- a/src/main/java/br/com/mili/milibackend/gfd/domain/usecases/GetAllGfdDocumentsStatusUseCase.java
+++ b/src/main/java/br/com/mili/milibackend/gfd/domain/usecases/GetAllGfdDocumentsStatusUseCase.java
@@ -1,0 +1,8 @@
+package br.com.mili.milibackend.gfd.domain.usecases;
+
+import br.com.mili.milibackend.gfd.application.dto.GfdMVerificarDocumentosInputDto;
+import br.com.mili.milibackend.gfd.application.dto.GfdMVerificarDocumentosOutputDto;
+
+public interface GetAllGfdDocumentsStatusUseCase {
+    GfdMVerificarDocumentosOutputDto execute(GfdMVerificarDocumentosInputDto inputDto);
+}

--- a/src/main/java/br/com/mili/milibackend/gfd/domain/usecases/GetAllSupplierDocumentsUseCase.java
+++ b/src/main/java/br/com/mili/milibackend/gfd/domain/usecases/GetAllSupplierDocumentsUseCase.java
@@ -1,0 +1,8 @@
+package br.com.mili.milibackend.gfd.domain.usecases;
+
+import br.com.mili.milibackend.gfd.application.dto.GfdMDocumentosGetAllInputDto;
+import br.com.mili.milibackend.gfd.application.dto.GfdMDocumentosGetAllOutputDto;
+
+public interface GetAllSupplierDocumentsUseCase {
+    GfdMDocumentosGetAllOutputDto execute(GfdMDocumentosGetAllInputDto inputDto);
+}

--- a/src/main/java/br/com/mili/milibackend/gfd/domain/usecases/GetAllTipoDocumentoUseCase.java
+++ b/src/main/java/br/com/mili/milibackend/gfd/domain/usecases/GetAllTipoDocumentoUseCase.java
@@ -1,0 +1,10 @@
+package br.com.mili.milibackend.gfd.domain.usecases;
+
+import br.com.mili.milibackend.gfd.application.dto.gfdTipoDocumento.GfdTipoDocumentoGetAllInputDto;
+import br.com.mili.milibackend.gfd.application.dto.gfdTipoDocumento.GfdTipoDocumentoGetAllOutputDto;
+
+import java.util.List;
+
+public interface GetAllTipoDocumentoUseCase {
+    List<GfdTipoDocumentoGetAllOutputDto> execute(GfdTipoDocumentoGetAllInputDto inputDto);
+}

--- a/src/main/java/br/com/mili/milibackend/gfd/domain/usecases/UpdateGfdDocumentoUseCase.java
+++ b/src/main/java/br/com/mili/milibackend/gfd/domain/usecases/UpdateGfdDocumentoUseCase.java
@@ -1,0 +1,9 @@
+package br.com.mili.milibackend.gfd.domain.usecases;
+
+import br.com.mili.milibackend.gfd.application.dto.gfdDocumento.GfdDocumentoUpdateInputDto;
+import br.com.mili.milibackend.gfd.application.dto.gfdDocumento.GfdDocumentoUpdateOutputDto;
+
+public interface UpdateGfdDocumentoUseCase {
+    GfdDocumentoUpdateOutputDto execute(GfdDocumentoUpdateInputDto inputDto) ;
+
+}

--- a/src/main/java/br/com/mili/milibackend/gfd/infra/fileprocess/FileProcessingServiceImpl.java
+++ b/src/main/java/br/com/mili/milibackend/gfd/infra/fileprocess/FileProcessingServiceImpl.java
@@ -7,6 +7,7 @@ import org.apache.tika.Tika;
 import org.springframework.stereotype.Service;
 import org.springframework.util.MimeType;
 
+import java.text.Normalizer;
 import java.util.UUID;
 
 @Service
@@ -21,7 +22,24 @@ public class FileProcessingServiceImpl implements FileProcessingService {
         byte[] fileData = Base64.decodeBase64(base64File);
         String mimeTypeStr = tika.detect(fileData);
         MimeType mimeType = MimeType.valueOf(mimeTypeStr);
-        String nomeArquivo = UUID.randomUUID() + "-" + originalFileName;
+        String nomeArquivo = UUID.randomUUID() + "-" + normalizeFileName(originalFileName);
         return new DocumentoFileData(fileData, mimeType.toString(), nomeArquivo, fileData.length);
+    }
+
+    private String normalizeFileName(String originalFileName) {
+        if(originalFileName == null) {
+            return null;
+        }
+
+        if(originalFileName.isEmpty()) {
+            return "";
+        }
+
+        var normalized = Normalizer.normalize(originalFileName, Normalizer.Form.NFD);
+        normalized = normalized.replaceAll("\\p{M}", "");
+
+        normalized = normalized.replaceAll("[^a-zA-Z0-9\\.\\-_]", "");
+
+        return normalized;
     }
 }

--- a/src/main/java/br/com/mili/milibackend/gfd/infra/repository/GfdDocumentoPeriodoRepository.java
+++ b/src/main/java/br/com/mili/milibackend/gfd/infra/repository/GfdDocumentoPeriodoRepository.java
@@ -1,0 +1,43 @@
+package br.com.mili.milibackend.gfd.infra.repository;
+
+
+import br.com.mili.milibackend.gfd.domain.entity.GfdDocumentoPeriodo;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDate;
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface GfdDocumentoPeriodoRepository extends JpaRepository<GfdDocumentoPeriodo, Integer>, JpaSpecificationExecutor<GfdDocumentoPeriodo> {
+    @Modifying
+    @Query("DELETE FROM GfdDocumentoPeriodo g WHERE g.gfdDocumento.id = :id")
+    void deleteByGfdDocumento_Id(Integer id);
+
+    @Query("SELECT g FROM GfdDocumentoPeriodo g WHERE g.gfdDocumento.id = :id")
+    Optional<GfdDocumentoPeriodo> getByGfdDocumento_Id(Integer id);
+
+    @Modifying
+    @Query(
+            value = """
+                    DELETE FROM gfd_documento_periodo
+                    WHERE ID IN (
+                        SELECT gfdp.ID
+                        FROM gfd_documento_periodo gfdp
+                        INNER JOIN ct_fornecedor_documentos cfd ON cfd.ID = gfdp.ID_DOCUMENTO
+                        INNER JOIN gfd_tipo_documento gtp ON gtp.ID = cfd.ID_TIPO_DOCUMENTO
+                        WHERE gtp.ID = :idTipoDocumento
+                          AND gfdp.periodo BETWEEN :periodoIncio AND :periodoFim
+                    )""",
+            nativeQuery = true
+    )
+    void deleteByPeriodoAndTipoDocumento(LocalDate periodoIncio, LocalDate periodoFim, Integer idTipoDocumento);
+
+    List<GfdDocumentoPeriodo> findByGfdDocumento_IdIn(Collection<Integer> gfdDocumentoIds);
+}

--- a/src/main/java/br/com/mili/milibackend/gfd/infra/repository/gfdDocumento/GfdDocumentoRepository.java
+++ b/src/main/java/br/com/mili/milibackend/gfd/infra/repository/gfdDocumento/GfdDocumentoRepository.java
@@ -6,24 +6,31 @@ import br.com.mili.milibackend.gfd.domain.interfaces.IGfdDocumentoCustomReposito
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDate;
 import java.util.List;
 
 public interface GfdDocumentoRepository extends JpaRepository<GfdDocumento, Integer>, JpaSpecificationExecutor<GfdDocumento>, IGfdDocumentoCustomRepository {
 
-    @Query(""" 
-            SELECT d
-              FROM GfdDocumento d
-                      LEFT JOIN FETCH d.gfdTipoDocumento
-              WHERE d.id IN (
-                  SELECT MAX(d2.id)
-                  FROM GfdDocumento d2
-                  WHERE d2.ctforCodigo = :codFornecedor
-                          AND (d2.gfdFuncionario.id = :idFuncionario or :idFuncionario is NULL )
-                  GROUP BY d2.gfdTipoDocumento.id
-              )""")
-    List<GfdDocumento> findLatestDocumentsGroupedByTipoAndFornecedorId(Integer codFornecedor, Integer idFuncionario);
-
-
+    @Query("""
+                SELECT d
+                FROM GfdDocumento d
+                     LEFT JOIN FETCH d.gfdTipoDocumento
+                     LEFT JOIN FETCH d.gfdDocumentoPeriodo gdp
+                WHERE d.id IN (
+                    SELECT MAX(d2.id)
+                    FROM GfdDocumento d2
+                         LEFT JOIN d2.gfdDocumentoPeriodo gdp2
+                    WHERE d2.ctforCodigo = :codFornecedor
+                          AND (:idFuncionario IS NULL OR d2.gfdFuncionario.id = :idFuncionario)
+                          AND (:periodo IS NULL OR :periodo BETWEEN gdp2.periodoInicial AND gdp2.periodoFinal)
+                    GROUP BY d2.gfdTipoDocumento.id
+                )
+            """)
+    List<GfdDocumento> findLatestDocumentsByPeriodoAndFornecedorOrFuncionario(
+            @Param("codFornecedor") Integer codFornecedor,
+            @Param("idFuncionario") Integer idFuncionario,
+            @Param("periodo") LocalDate periodo);
 
 }

--- a/src/main/java/br/com/mili/milibackend/gfd/infra/repository/gfdDocumento/GfdDocumentoRepositoryImpl.java
+++ b/src/main/java/br/com/mili/milibackend/gfd/infra/repository/gfdDocumento/GfdDocumentoRepositoryImpl.java
@@ -1,6 +1,7 @@
 package br.com.mili.milibackend.gfd.infra.repository.gfdDocumento;
 
 import br.com.mili.milibackend.gfd.domain.entity.GfdDocumento;
+import br.com.mili.milibackend.gfd.domain.entity.GfdDocumentoPeriodo;
 import br.com.mili.milibackend.gfd.domain.entity.GfdFuncionario;
 import br.com.mili.milibackend.gfd.domain.entity.GfdTipoDocumento;
 import br.com.mili.milibackend.gfd.domain.interfaces.IGfdDocumentoCustomRepository;

--- a/src/main/java/br/com/mili/milibackend/gfd/infra/specification/GfdDocumentoSpecification.java
+++ b/src/main/java/br/com/mili/milibackend/gfd/infra/specification/GfdDocumentoSpecification.java
@@ -1,7 +1,10 @@
 package br.com.mili.milibackend.gfd.infra.specification;
 
 import br.com.mili.milibackend.gfd.domain.entity.GfdDocumento;
+import br.com.mili.milibackend.gfd.domain.entity.GfdDocumentoPeriodo;
 import br.com.mili.milibackend.gfd.domain.entity.GfdDocumentoStatusEnum;
+import jakarta.persistence.criteria.Join;
+import jakarta.persistence.criteria.JoinType;
 import jakarta.persistence.criteria.Path;
 import org.springframework.data.jpa.domain.Specification;
 
@@ -78,6 +81,25 @@ public class GfdDocumentoSpecification {
             return cb.lessThanOrEqualTo(dataCadastrooPath, dataFim);
         };
     }
+
+    public static Specification<GfdDocumento> filtroPeriodo(LocalDate periodo) {
+        return (root, query, cb) -> {
+            if (periodo == null) {
+                return null;
+            }
+
+            Join<GfdDocumento, GfdDocumentoPeriodo> periodoJoin = root.join("gfdDocumentoPeriodo");
+            Path<LocalDate> periodoInicialPath = periodoJoin.get("periodoInicial");
+            Path<LocalDate> periodoFinalPath = periodoJoin.get("periodoFinal");
+
+            return cb.between(
+                    cb.literal(periodo),
+                    periodoInicialPath,
+                    periodoFinalPath
+            );
+        };
+    }
+
 
     public static Specification<GfdDocumento> filtroRangeDataValidade(LocalDate dataInicio, LocalDate dataFim) {
         return (root, query, cb) -> {

--- a/src/main/java/br/com/mili/milibackend/shared/exception/types/ConflictException.java
+++ b/src/main/java/br/com/mili/milibackend/shared/exception/types/ConflictException.java
@@ -1,0 +1,22 @@
+package br.com.mili.milibackend.shared.exception.types;
+
+public class ConflictException extends CustomException {
+    private final int status;
+    private final String code;
+
+    public ConflictException(String message, String code) {
+        super(message);
+        this.status = 409;
+        this.code = code;
+    }
+
+    @Override
+    public int getStatus() {
+        return status;
+    }
+
+    @Override
+    public String getCode() {
+        return code;
+    }
+}

--- a/src/test/java/br/com/mili/milibackend/fornecedor/application/service/GfdDocumentoServiceTest.java
+++ b/src/test/java/br/com/mili/milibackend/fornecedor/application/service/GfdDocumentoServiceTest.java
@@ -58,19 +58,20 @@ class GfdDocumentoServiceTest {
 
         var outputDto = new FindLatestDocumentsGroupedByTipoAndFornecedorIdOutputDto();
 
-        when(gfdDocumentoRepository.findLatestDocumentsGroupedByTipoAndFornecedorId(10, null))
+        when(gfdDocumentoRepository.findLatestDocumentsByPeriodoAndFornecedorOrFuncionario(10, null, null))
                 .thenReturn(List.of(gfdDocumento));
 
         when(modelMapper.map(gfdDocumento, FindLatestDocumentsGroupedByTipoAndFornecedorIdOutputDto.class))
                 .thenReturn(outputDto);
 
-        var result = gfdDocumentoService.findLatestDocumentsGroupedByTipoAndFornecedorId(10, null);
+        var result = gfdDocumentoService.findLatestDocumentsGroupedByTipoAndFornecedorId(10, null, null);
 
         assertNotNull(result);
         assertEquals(1, result.size());
         assertSame(outputDto, result.get(0));
     }
 
+/*
     @Test
     void test_GetAll__deve_retornar_pagina_com_filtros() {
         var inputDto = new GfdDocumentoGetAllInputDto();
@@ -207,6 +208,7 @@ class GfdDocumentoServiceTest {
 
         assertThrows(NotFoundException.class, () -> gfdDocumentoService.update(inputDto));
     }
+*/
 
     @Test
     void test_Download__deve_retornar_url_quando_documento_existir() {

--- a/src/test/java/br/com/mili/milibackend/fornecedor/application/usecases/GetFornecedorByCodOrIdUseCaseImplTest.java
+++ b/src/test/java/br/com/mili/milibackend/fornecedor/application/usecases/GetFornecedorByCodOrIdUseCaseImplTest.java
@@ -1,0 +1,84 @@
+package br.com.mili.milibackend.fornecedor.application.usecases;
+
+import br.com.mili.milibackend.fornecedor.domain.entity.Fornecedor;
+import br.com.mili.milibackend.fornecedor.infra.repository.fornecedorRepository.FornecedorRepository;
+import br.com.mili.milibackend.shared.exception.types.NotFoundException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+
+import java.util.Optional;
+
+import static br.com.mili.milibackend.gfd.adapter.exception.GfdMCodeException.GFD_FORNECEDOR_NAO_ENCONTRADO;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(org.mockito.junit.jupiter.MockitoExtension.class)
+class GetFornecedorByCodOrIdUseCaseImplTest {
+
+    @Mock
+    private FornecedorRepository fornecedorRepository;
+
+    @InjectMocks
+    private GetFornecedorByCodOrIdUseCaseImpl useCase;
+
+    private Fornecedor fornecedor;
+
+    @BeforeEach
+    public void setUp() {
+        fornecedor = new Fornecedor();
+        fornecedor.setCodigo(1);
+        fornecedor.setCodUsuario(1);
+        fornecedor.setRazaoSocial("Fornecedor 1");
+    }
+
+
+    @Test
+    public void test_deve_buscar_fornecedor_quando_enviar_id() {
+        when(fornecedorRepository.findById(1)).thenReturn(Optional.of(fornecedor));
+
+        // Act
+        var fornecedorOut = useCase.execute(null, 1);
+
+        // Assert
+        assertEquals(fornecedor.getCodigo(), fornecedorOut.getCodigo());
+    }
+
+    @Test
+    public void test_deve_lancar_excecao_quando_nao_encontrar_por_id_fornecedor() {
+        when(fornecedorRepository.findById(1)).thenReturn(Optional.empty());
+
+        // Act
+        NotFoundException ex = assertThrows( NotFoundException.class, () -> useCase.execute(null, 1));
+
+        // Assert
+        assertEquals(GFD_FORNECEDOR_NAO_ENCONTRADO.getMensagem(), ex.getMessage());
+        assertEquals(GFD_FORNECEDOR_NAO_ENCONTRADO.getCode(), ex.getCode());
+    }
+
+    @Test
+    public void test_deve_buscar_fornecedor_quando_enviar_cod() {
+        when(fornecedorRepository.findByCodUsuario(1)).thenReturn(Optional.of(fornecedor));
+
+        // Act
+        var fornecedorOut = useCase.execute(1, null);
+
+        // Assert
+        assertEquals(fornecedor.getCodigo(), fornecedorOut.getCodigo());
+    }
+
+    @Test
+    public void test_deve_lancar_excecao_quando_nao_encontrar_cod_fornecedor() {
+        when(fornecedorRepository.findByCodUsuario(1)).thenReturn(Optional.empty());
+
+        // Act
+        NotFoundException ex = assertThrows( NotFoundException.class, () -> useCase.execute(1, null));
+
+        // Assert
+        assertEquals(GFD_FORNECEDOR_NAO_ENCONTRADO.getMensagem(), ex.getMessage());
+        assertEquals(GFD_FORNECEDOR_NAO_ENCONTRADO.getCode(), ex.getCode());
+    }
+}

--- a/src/test/java/br/com/mili/milibackend/gfd/application/service/GfdManagerServiceTest.java
+++ b/src/test/java/br/com/mili/milibackend/gfd/application/service/GfdManagerServiceTest.java
@@ -2,22 +2,19 @@ package br.com.mili.milibackend.gfd.application.service;
 
 import br.com.mili.milibackend.envioEmail.domain.entity.EnvioEmail;
 import br.com.mili.milibackend.envioEmail.domain.interfaces.IEnvioEmailService;
-import br.com.mili.milibackend.fornecedor.application.dto.FornecedorGetByCodUsuarioInputDto;
-import br.com.mili.milibackend.fornecedor.application.dto.FornecedorGetByCodUsuarioOutputDto;
 import br.com.mili.milibackend.fornecedor.application.dto.FornecedorGetByIdOutputDto;
 import br.com.mili.milibackend.fornecedor.domain.entity.Fornecedor;
 import br.com.mili.milibackend.fornecedor.domain.interfaces.service.IFornecedorService;
+import br.com.mili.milibackend.fornecedor.domain.usecases.GetFornecedorByCodOrIdUseCase;
 import br.com.mili.milibackend.gfd.application.dto.*;
 import br.com.mili.milibackend.gfd.application.dto.gfdDocumento.*;
 import br.com.mili.milibackend.gfd.application.dto.gfdFuncionario.*;
-import br.com.mili.milibackend.gfd.application.dto.gfdTipoDocumento.GfdTipoDocumentoGetAllOutputDto;
-import br.com.mili.milibackend.gfd.application.dto.gfdTipoDocumento.GfdTipoDocumentoGetByIdOutputDto;
 import br.com.mili.milibackend.gfd.domain.entity.GfdDocumentoStatusEnum;
-import br.com.mili.milibackend.gfd.domain.entity.GfdTipoDocumentoTipoEnum;
 import br.com.mili.milibackend.gfd.domain.interfaces.IGfdDocumentoService;
 import br.com.mili.milibackend.gfd.domain.interfaces.IGfdFuncionarioService;
-import br.com.mili.milibackend.gfd.domain.interfaces.IGfdTipoDocumentoService;
+import br.com.mili.milibackend.gfd.domain.usecases.DeleteGfdDocumentoUseCase;
 import br.com.mili.milibackend.gfd.domain.usecases.GetAllGfdFuncionarioUseCase;
+import br.com.mili.milibackend.gfd.domain.usecases.UpdateGfdDocumentoUseCase;
 import br.com.mili.milibackend.shared.exception.types.ForbiddenException;
 import br.com.mili.milibackend.shared.exception.types.NotFoundException;
 import br.com.mili.milibackend.shared.page.pagination.PageBaseImpl;
@@ -26,13 +23,10 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.modelmapper.ModelMapper;
 
 import java.time.LocalDate;
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 
 import static br.com.mili.milibackend.gfd.adapter.exception.GfdMCodeException.GFD_FORNECEDOR_NAO_ENCONTRADO;
@@ -49,16 +43,16 @@ class GfdManagerServiceTest {
     private GfdManagerService gfdManagerService;
 
     @Mock
-    private IFornecedorService fornecedorService;
-
-    @Mock
     private IEnvioEmailService envioEmailService;
 
     @Mock
     private IGfdFuncionarioService gfdFuncionarioService;
 
     @Mock
-    private IGfdTipoDocumentoService gfdTipoDocumentoService;
+    private UpdateGfdDocumentoUseCase updateGfdDocumentoUseCase;
+
+    @Mock
+    private DeleteGfdDocumentoUseCase deleteGfdDocumentoUseCase;
 
     @Mock
     private IGfdDocumentoService gfdDocumentoService;
@@ -68,6 +62,9 @@ class GfdManagerServiceTest {
 
     @Mock
     private GetAllGfdFuncionarioUseCase getAllGfdFuncionarioUseCase;
+
+    @Mock
+    private GetFornecedorByCodOrIdUseCase getFornecedorByCodOrIdUseCase;
 
     @Mock
     private Tika tika;
@@ -112,15 +109,9 @@ class GfdManagerServiceTest {
         fornecedor.setContato("Contato");
         fornecedor.setEmail("email@teste.com");
         fornecedor.setCelular("123456789");
+        fornecedor.setAceiteLgpd(1);
 
-        var fornecedorGetByIdOutputDto = new FornecedorGetByIdOutputDto();
-        fornecedorGetByIdOutputDto.setRazaoSocial("Teste");
-        fornecedorGetByIdOutputDto.setContato("Contato");
-        fornecedorGetByIdOutputDto.setEmail("email@teste.com");
-        fornecedorGetByIdOutputDto.setCelular("123456789");
-
-        when(fornecedorService.getById(1)).thenReturn(fornecedorGetByIdOutputDto);
-        when(modelMapper.map(any(), eq(Fornecedor.class))).thenReturn(fornecedor);
+        when(getFornecedorByCodOrIdUseCase.execute(null, 1)).thenReturn(fornecedor);
 
         // Act
         GfdMVerificarFornecedorOutputDto outputDto = gfdManagerService.verifyFornecedor(inputDto);
@@ -136,7 +127,11 @@ class GfdManagerServiceTest {
         GfdMVerificarFornecedorInputDto inputDto = new GfdMVerificarFornecedorInputDto();
         inputDto.setId(1);
 
-        when(fornecedorService.getById(1)).thenReturn(null);
+        when(getFornecedorByCodOrIdUseCase.execute(null, 1))
+                .thenThrow(new NotFoundException(
+                        GFD_FORNECEDOR_NAO_ENCONTRADO.getMensagem(),
+                        GFD_FORNECEDOR_NAO_ENCONTRADO.getCode()
+                ));
 
         // Act & Assert
         NotFoundException ex = assertThrows(NotFoundException.class, () -> gfdManagerService.verifyFornecedor(inputDto));
@@ -152,13 +147,13 @@ class GfdManagerServiceTest {
 
         var fornecedor = new Fornecedor();
         fornecedor.setRazaoSocial("Teste");
+        fornecedor.setContato("Contato");
+        fornecedor.setEmail("email@teste.com");
+        fornecedor.setCelular("123456789");
+        fornecedor.setAceiteLgpd(0);
+        fornecedor.setCodUsuario(123);
 
-        var fornecedorGetByCodUsuarioOutputDto = new FornecedorGetByCodUsuarioOutputDto();
-        fornecedorGetByCodUsuarioOutputDto.setRazaoSocial("Teste");
-
-
-        when(fornecedorService.getByCodUsuario(any(FornecedorGetByCodUsuarioInputDto.class))).thenReturn(fornecedorGetByCodUsuarioOutputDto);
-        when(modelMapper.map(any(), eq(Fornecedor.class))).thenReturn(fornecedor);
+        when(getFornecedorByCodOrIdUseCase.execute(123, null)).thenReturn(fornecedor);
 
         // Act
         GfdMVerificarFornecedorOutputDto outputDto = gfdManagerService.verifyFornecedor(inputDto);
@@ -169,84 +164,20 @@ class GfdManagerServiceTest {
     }
 
     @Test
-    void test_VerifyDocumentos__deve_retornar_status_nao_enviado_e_outros_quando_sem_documentos() {
-        // Arrange
-        GfdMVerificarDocumentosInputDto inputDto = new GfdMVerificarDocumentosInputDto();
-        inputDto.setId(1);
-
-        Fornecedor fornecedor = new Fornecedor();
-        fornecedor.setCodigo(1);
-
-        var fornecedorGetByIdOutputDto = new FornecedorGetByIdOutputDto();
-        fornecedor.setCodigo(1);
-
-        when(fornecedorService.getById(1)).thenReturn(fornecedorGetByIdOutputDto);
-
-        when(modelMapper.map(any(), eq(Fornecedor.class))).thenReturn(fornecedor);
-        when(gfdDocumentoService.findLatestDocumentsGroupedByTipoAndFornecedorId(1, null)).thenReturn(Collections.emptyList());
-        when(gfdTipoDocumentoService.getAll(any())).thenReturn(Arrays.asList(
-                new GfdTipoDocumentoGetAllOutputDto(1, "Doc1", GfdTipoDocumentoTipoEnum.FORNECEDOR, 30, true, true),
-                new GfdTipoDocumentoGetAllOutputDto(2, "Doc2", GfdTipoDocumentoTipoEnum.FORNECEDOR, 30, false, true)
-        ));
-
-        // Act
-        GfdMVerificarDocumentosOutputDto outputDtoList = gfdManagerService.verifyDocumentos(inputDto);
-
-        // Assert
-        assertEquals(2, outputDtoList.getDocumentos().size());
-        assertEquals("NÃO ENVIADO", outputDtoList.getDocumentos().get(1).getStatus());
-        assertEquals("OPCIONAL", outputDtoList.getDocumentos().get(0).getStatus());
-    }
-
-    @Test
-    void test_VerifyDocumentos__deve_retornar_status_conforme_e_outros_quando_documentos_obrigatorios_existem() {
-        // Arrange
-        GfdMVerificarDocumentosInputDto inputDto = new GfdMVerificarDocumentosInputDto();
-        inputDto.setId(1);
-
-        Fornecedor fornecedor = new Fornecedor();
-        fornecedor.setCodigo(1);
-
-        FindLatestDocumentsGroupedByTipoAndFornecedorIdOutputDto doc = new FindLatestDocumentsGroupedByTipoAndFornecedorIdOutputDto();
-        doc.setStatus(GfdDocumentoStatusEnum.CONFORME);
-        doc.setGfdTipoDocumento(new FindLatestDocumentsGroupedByTipoAndFornecedorIdOutputDto.GfdTipoDocumentoDto(1, "Doc1", 30));
-
-        var fornecedorGetByIdOutputDto = new FornecedorGetByIdOutputDto();
-        fornecedor.setCodigo(1);
-
-        when(fornecedorService.getById(1)).thenReturn(fornecedorGetByIdOutputDto);
-
-        when(modelMapper.map(any(), eq(Fornecedor.class))).thenReturn(fornecedor);
-        when(gfdDocumentoService.findLatestDocumentsGroupedByTipoAndFornecedorId(1, null)).thenReturn(Arrays.asList(doc));
-        when(gfdTipoDocumentoService.getAll(any())).thenReturn(Arrays.asList(
-                new GfdTipoDocumentoGetAllOutputDto(1, "Doc1", GfdTipoDocumentoTipoEnum.FORNECEDOR, 30, true, true),
-                new GfdTipoDocumentoGetAllOutputDto(2, "Doc2", GfdTipoDocumentoTipoEnum.FORNECEDOR, 30, false, true)
-        ));
-
-        // Act
-        GfdMVerificarDocumentosOutputDto outputDtoList = gfdManagerService.verifyDocumentos(inputDto);
-
-        // Assert
-        assertEquals(2, outputDtoList.getDocumentos().size());
-        assertEquals("CONFORME", outputDtoList.getDocumentos().get(1).getStatus());
-        assertEquals("OPCIONAL", outputDtoList.getDocumentos().get(0).getStatus());
-    }
-
-    @Test
     void test_GetFornecedor__deve_retornar_fornecedor_quando_encontrado_por_id() {
         // Arrange
         GfdMFornecedorGetInputDto inputDto = new GfdMFornecedorGetInputDto();
         inputDto.setId(1);
 
-        Fornecedor fornecedor = new Fornecedor();
+        var fornecedor = new Fornecedor();
         fornecedor.setRazaoSocial("Teste");
+        fornecedor.setContato("Contato");
+        fornecedor.setEmail("email@teste.com");
+        fornecedor.setCelular("123456789");
+        fornecedor.setAceiteLgpd(0);
+        fornecedor.setCodUsuario(123);
 
-        var fornecedorGetByIdOutputDto = new FornecedorGetByIdOutputDto();
-        fornecedor.setCodigo(1);
-
-        when(fornecedorService.getById(1)).thenReturn(fornecedorGetByIdOutputDto);
-
-        when(modelMapper.map(any(), eq(Fornecedor.class))).thenReturn(fornecedor);
+        when(getFornecedorByCodOrIdUseCase.execute(null, 1)).thenReturn(fornecedor);
         when(modelMapper.map(fornecedor, GfdMFornecedorGetOutputDto.class)).thenReturn(new GfdMFornecedorGetOutputDto());
 
         // Act
@@ -254,228 +185,6 @@ class GfdManagerServiceTest {
 
         // Assert
         assertNotNull(outputDto);
-    }
-
-    @Test
-    void test_GetFornecedor__deve_lancar_not_found_exception_quando_fornecedor_nao_encontrado() {
-        // Arrange
-        GfdMFornecedorGetInputDto inputDto = new GfdMFornecedorGetInputDto();
-        inputDto.setId(1);
-
-        when(fornecedorService.getById(1)).thenReturn(null);
-
-        // Act & Assert
-        NotFoundException ex = assertThrows(NotFoundException.class, () -> gfdManagerService.getFornecedor(inputDto));
-        assertEquals(GFD_FORNECEDOR_NAO_ENCONTRADO.getMensagem(), ex.getMessage());
-        assertEquals(GFD_FORNECEDOR_NAO_ENCONTRADO.getCode(), ex.getCode());
-    }
-
-
-/*    @Test
-    void test_GetAllDocumentos__deve_retornar_lista_vazia_quando_sem_documentos() {
-        // Arrange
-        GfdMDocumentosGetAllInputDto inputDto = new GfdMDocumentosGetAllInputDto();
-        inputDto.setId(1);
-
-        Fornecedor fornecedor = new Fornecedor();
-        fornecedor.setCodigo(1);
-
-        var fornecedorGetByIdOutputDto = new FornecedorGetByIdOutputDto();
-        fornecedorGetByIdOutputDto.setCodigo(1);
-
-        when(fornecedorService.getById(1)).thenReturn(fornecedorGetByIdOutputDto);
-        when(modelMapper.map(any(), eq(Fornecedor.class))).thenReturn(fornecedor);
-
-        var gfdDocumentoGetAllInputDto = new GfdDocumentoGetAllInputDto();
-        when(modelMapper.map(any(), eq(GfdDocumentoGetAllInputDto.class))).thenReturn(gfdDocumentoGetAllInputDto);
-
-        when(gfdDocumentoService.getAll(any())).thenReturn(new PageBaseImpl<>(Collections.emptyList(), 1, 10, 0));
-
-        // Act
-        GfdMDocumentosGetAllOutputDto outputDto = gfdManagerService.getAllDocumentos(inputDto);
-
-        // Assert
-        assertNotNull(outputDto);
-        assertTrue(outputDto.getGfdDocumento().getContent().isEmpty());
-    }*/
-
-/*    @Test
-    void test_GetAllDocumentos__deve_retornar_dados_corretos_quando_tipo_documento_especificado_e_sem_documentos() {
-        // Arrange
-        GfdMDocumentosGetAllInputDto inputDto = new GfdMDocumentosGetAllInputDto();
-        inputDto.setId(1);
-        inputDto.setTipoDocumentoId(1);
-
-        FornecedorGetByIdOutputDto fornecedorGetByIdOutputDto = new FornecedorGetByIdOutputDto();
-        fornecedorGetByIdOutputDto.setCodigo(1);
-
-        Fornecedor fornecedor = new Fornecedor();
-        fornecedor.setCodigo(1);
-
-        GfdTipoDocumentoGetByIdOutputDto tipoDocumento = new GfdTipoDocumentoGetByIdOutputDto();
-        tipoDocumento.setId(1);
-        tipoDocumento.setNome("Doc1");
-
-        when(fornecedorService.getById(1)).thenReturn(fornecedorGetByIdOutputDto);
-        when(modelMapper.map(fornecedorGetByIdOutputDto, Fornecedor.class)).thenReturn(fornecedor);
-
-        GfdDocumentoGetAllInputDto gfdDocumentoGetAllInputDto = new GfdDocumentoGetAllInputDto();
-        when(modelMapper.map(inputDto, GfdDocumentoGetAllInputDto.class)).thenReturn(gfdDocumentoGetAllInputDto);
-
-        when(gfdDocumentoService.getAll(any())).thenReturn(new PageBaseImpl<>(Collections.emptyList(), 1, 10, 0));
-        when(gfdTipoDocumentoService.getById(1)).thenReturn(tipoDocumento);
-
-        // Act
-        GfdMDocumentosGetAllOutputDto outputDto = gfdManagerService.getAllDocumentos(inputDto);
-
-        // Assert
-        assertNotNull(outputDto);
-        assertNotNull(outputDto.getGfdDocumento());
-        assertTrue(outputDto.getGfdDocumento().getContent().isEmpty(), "A lista de documentos deve estar vazia");
-        assertNotNull(outputDto.getGfdTipoDocumento());
-        assertEquals(1, outputDto.getGfdTipoDocumento().getId(), "O ID do tipo de documento deve ser 1");
-        assertEquals("Doc1", outputDto.getGfdTipoDocumento().getNome(), "O nome do tipo de documento deve ser 'Doc1'");
-    }*/
-
-/*
-    @Test
-    void test_GetAllDocumentos__deve_retornar_documentos_funcionario_quando_tipo_documento_especificado() {
-        // Arrange
-        GfdMDocumentosGetAllInputDto inputDto = new GfdMDocumentosGetAllInputDto();
-        inputDto.setId(1);
-        inputDto.setTipoDocumentoId(1);
-
-        var funcionario = new GfdMDocumentosGetAllInputDto.FuncionarioDto();
-        funcionario.setId(1);
-        inputDto.setFuncionario(funcionario);
-
-        var fornecedorGetByIdOutputDto = new FornecedorGetByIdOutputDto();
-        fornecedorGetByIdOutputDto.setCodigo(1);
-
-        var fornecedor = new Fornecedor();
-        fornecedor.setCodigo(1);
-
-        var tipoDocumento = new GfdTipoDocumentoGetByIdOutputDto();
-        tipoDocumento.setId(1);
-        tipoDocumento.setNome("Doc1");
-        tipoDocumento.setDiasValidade(180);
-
-        var documento1 = buildDocumento();
-        documento1.setId(1);
-        var documento2 = buildDocumento();
-        documento2.setId(2);
-
-        var documentos = Arrays.asList(documento1, documento2);
-
-        // Mock do funcionario
-        var funcionarioDto = new GfdFuncionarioGetByIdOutputDto();
-        funcionarioDto.setId(funcionario.getId());
-        funcionarioDto.setTipoContratacao(GfdFuncionarioTipoContratacaoEnum.CLT.getDescricao());
-
-        when(gfdFuncionarioService.getById(any())).thenReturn(funcionarioDto);
-
-        // Mock do fornecedor
-        when(fornecedorService.getById(1)).thenReturn(fornecedorGetByIdOutputDto);
-        when(modelMapper.map(fornecedorGetByIdOutputDto, Fornecedor.class)).thenReturn(fornecedor);
-
-
-        // Mock do input mapeado
-        var gfdDocumentoGetAllInputDto = new GfdDocumentoGetAllInputDto();
-        when(modelMapper.map(inputDto, GfdDocumentoGetAllInputDto.class)).thenReturn(gfdDocumentoGetAllInputDto);
-
-        // Mock do retorno de documentos
-        when(gfdDocumentoService.getAll(any())).thenReturn(new PageBaseImpl<>(documentos, 1, 10, 2));
-
-        GfdMDocumentosGetAllOutputDto.GfdDocumentoDto.GfdTipoDocumentoDto tipoDto = new GfdMDocumentosGetAllOutputDto.GfdDocumentoDto.GfdTipoDocumentoDto();
-        tipoDto.setId(1);
-        tipoDto.setNome("Doc1");
-        tipoDto.setDiasValidade(180);
-
-        var documentoDto1 = new GfdMDocumentosGetAllOutputDto.GfdDocumentoDto();
-        documentoDto1.setId(1);
-        documentoDto1.setNomeArquivo("nf-123456.pdf");
-        documentoDto1.setGfdTipoDocumento(tipoDto);
-
-        var documentoDto2 = new GfdMDocumentosGetAllOutputDto.GfdDocumentoDto();
-        documentoDto2.setId(2);
-        documentoDto2.setNomeArquivo("nf-654321.pdf");
-        documentoDto2.setGfdTipoDocumento(tipoDto);
-
-        when(modelMapper.map(eq(documento1), eq(GfdMDocumentosGetAllOutputDto.GfdDocumentoDto.class))).thenReturn(documentoDto1);
-        when(modelMapper.map(eq(documento2), eq(GfdMDocumentosGetAllOutputDto.GfdDocumentoDto.class))).thenReturn(documentoDto2);
-
-        // Act
-        var outputDto = gfdManagerService.getAllDocumentos(inputDto);
-
-        // Assert
-        assertNotNull(outputDto);
-        assertNotNull(outputDto.getGfdDocumento());
-        assertEquals(2, outputDto.getGfdDocumento().getContent().size(), "Deve retornar 2 documentos");
-
-        assertEquals(1, outputDto.getGfdDocumento().getContent().get(0).getId());
-        assertEquals(2, outputDto.getGfdDocumento().getContent().get(1).getId());
-
-        assertNotNull(outputDto.getGfdTipoDocumento());
-        assertEquals(1, outputDto.getGfdTipoDocumento().getId(), "ID do tipo de documento deve ser 1");
-        assertEquals("Doc1", outputDto.getGfdTipoDocumento().getNome(), "Nome deve ser 'Doc1'");
-        assertEquals(180, outputDto.getGfdTipoDocumento().getDiasValidade(), "Dias de validade deve ser 180");
-    }
-*/
-
-    @Test
-    void test_GetAllDocumentos__deve_calcular_navegacao_nextDoc_previousDoc_corretamente() {
-        // Arrange
-        var inputDto = new GfdMDocumentosGetAllInputDto();
-        inputDto.setId(1);
-
-        inputDto.setTipoDocumentoId(2);
-
-        // Coloca funcionario para pegar lista de tipo FUNCIONARIO
-        var funcionario = new GfdMDocumentosGetAllInputDto.FuncionarioDto();
-        funcionario.setId(1);
-        inputDto.setFuncionario(funcionario);
-
-        var fornecedorGetByIdOutputDto = new FornecedorGetByIdOutputDto();
-        fornecedorGetByIdOutputDto.setCodigo(1);
-
-        var fornecedor = new Fornecedor();
-        fornecedor.setCodigo(1);
-
-        var tiposDocumento = Arrays.asList(
-                new GfdTipoDocumentoGetAllOutputDto(1, "Tipo 1", GfdTipoDocumentoTipoEnum.FUNCIONARIO_CLT, 100, true, true),
-                new GfdTipoDocumentoGetAllOutputDto(2, "Tipo 2", GfdTipoDocumentoTipoEnum.FUNCIONARIO_CLT, 100, true, true),
-                new GfdTipoDocumentoGetAllOutputDto(3, "Tipo 3", GfdTipoDocumentoTipoEnum.FUNCIONARIO_CLT, 100, true, true)
-        );
-
-        // Mocks
-        when(fornecedorService.getById(1)).thenReturn(fornecedorGetByIdOutputDto);
-        when(modelMapper.map(fornecedorGetByIdOutputDto, Fornecedor.class)).thenReturn(fornecedor);
-
-        var gfdDocumentoGetAllInputDto = new GfdDocumentoGetAllInputDto();
-        when(modelMapper.map(inputDto, GfdDocumentoGetAllInputDto.class)).thenReturn(gfdDocumentoGetAllInputDto);
-
-        when(gfdDocumentoService.getAll(any())).thenReturn(new PageBaseImpl<>(Collections.emptyList(), 1, 10, 0));
-
-        var tipoDocumentoAtual = new GfdTipoDocumentoGetByIdOutputDto();
-        tipoDocumentoAtual.setId(2);
-        tipoDocumentoAtual.setNome("Tipo 2");
-        tipoDocumentoAtual.setDiasValidade(120);
-
-        when(gfdTipoDocumentoService.getById(2)).thenReturn(tipoDocumentoAtual);
-
-
-        var serviceSpy = Mockito.spy(gfdManagerService);
-        doReturn(tiposDocumento).when(serviceSpy).getFornecedorTipoDocumentos(funcionario.getId());
-
-        // Act
-        var outputDto = serviceSpy.getAllDocumentos(inputDto);
-
-        // Assert
-        assertNotNull(outputDto);
-
-        // Espera que previousDoc seja o id anterior (1) e nextDoc seja o próximo (3)
-        assertEquals(3, outputDto.getNextDoc(), "nextDoc deve ser 3");
-        assertEquals(1, outputDto.getPreviousDoc(), "previousDoc deve ser 1");
     }
 
     @Test
@@ -498,10 +207,6 @@ class GfdManagerServiceTest {
         inputDto.setFuncionario(funcionarioInputDto);
 
         // Fornecedor mapeado
-        FornecedorGetByIdOutputDto fornecedorDto = new FornecedorGetByIdOutputDto();
-        fornecedorDto.setCodigo(codFornecedor);
-        fornecedorDto.setCodUsuario(codUsuario);
-
         Fornecedor fornecedor = new Fornecedor();
         fornecedor.setCodigo(codFornecedor);
         fornecedor.setCodUsuario(codUsuario);
@@ -523,8 +228,7 @@ class GfdManagerServiceTest {
         funcionarioOutputDto.setNome("João");
 
         // Mocks
-        when(fornecedorService.getById(codFornecedor)).thenReturn(fornecedorDto);
-        when(modelMapper.map(fornecedorDto, Fornecedor.class)).thenReturn(fornecedor);
+        when(getFornecedorByCodOrIdUseCase.execute(codUsuario, codFornecedor)).thenReturn(fornecedor);
         when(modelMapper.map(funcionarioInputDto, GfdFuncionarioCreateInputDto.class)).thenReturn(new GfdFuncionarioCreateInputDto());
         when(gfdFuncionarioService.create(any())).thenReturn(funcionarioCriado);
         when(modelMapper.map(funcionarioCriado, GfdMFuncionarioCreateOutputDto.GfdFuncionarioDto.class)).thenReturn(funcionarioOutputDto);
@@ -554,16 +258,10 @@ class GfdManagerServiceTest {
         inputDto.setCodUsuario(codUsuario);
         inputDto.setFuncionario(funcDto);
 
-        var fornecedorGetByIdDto = new FornecedorGetByIdOutputDto();
-        fornecedorGetByIdDto.setCodigo(codFornecedor);
-        fornecedorGetByIdDto.setCodUsuario(333);
-        when(fornecedorService.getById(codFornecedor)).thenReturn(fornecedorGetByIdDto);
-
         var fornecedorEntity = new Fornecedor();
         fornecedorEntity.setCodigo(codFornecedor);
         fornecedorEntity.setCodUsuario(333);
-        when(modelMapper.map(fornecedorGetByIdDto, Fornecedor.class))
-                .thenReturn(fornecedorEntity);
+        when(getFornecedorByCodOrIdUseCase.execute(codUsuario, codFornecedor)).thenReturn(fornecedorEntity);
 
         // Act
         var ex = assertThrows(ForbiddenException.class, () -> gfdManagerService.createFuncionario(inputDto));
@@ -588,16 +286,11 @@ class GfdManagerServiceTest {
         inputDto.setCodUsuario(codUsuario);
         inputDto.setFuncionario(funcDto);
 
-        var fornecedorGetByIdDto = new FornecedorGetByIdOutputDto();
-        fornecedorGetByIdDto.setCodigo(codFornecedor);
-        fornecedorGetByIdDto.setCodUsuario(codUsuario);
-        when(fornecedorService.getById(codFornecedor)).thenReturn(fornecedorGetByIdDto);
-
         var fornecedorEntity = new Fornecedor();
         fornecedorEntity.setCodigo(codFornecedor);
         fornecedorEntity.setCodUsuario(codUsuario);
-        when(modelMapper.map(fornecedorGetByIdDto, Fornecedor.class))
-                .thenReturn(fornecedorEntity);
+        when(getFornecedorByCodOrIdUseCase.execute(codUsuario, codFornecedor)).thenReturn(fornecedorEntity);
+
 
         var domainUpdateInput = new GfdFuncionarioUpdateInputDto();
         domainUpdateInput.setId(idFuncionario);
@@ -644,17 +337,10 @@ class GfdManagerServiceTest {
         inputDto.setCodUsuario(codUsuario);
         inputDto.setFuncionario(funcDto);
 
-        var fornecedorGetByIdDto = new FornecedorGetByIdOutputDto();
-        fornecedorGetByIdDto.setCodigo(codFornecedor);
-        fornecedorGetByIdDto.setCodUsuario(333);
-        when(fornecedorService.getById(codFornecedor)).thenReturn(fornecedorGetByIdDto);
-
         var fornecedorEntity = new Fornecedor();
         fornecedorEntity.setCodigo(codFornecedor);
         fornecedorEntity.setCodUsuario(333);
-        when(modelMapper.map(fornecedorGetByIdDto, Fornecedor.class))
-                .thenReturn(fornecedorEntity);
-
+        when(getFornecedorByCodOrIdUseCase.execute(codUsuario, codFornecedor)).thenReturn(fornecedorEntity);
         // Act
         var ex = assertThrows(ForbiddenException.class, () -> gfdManagerService.updateFuncionario(inputDto));
         assertEquals(GFD_FUNCIONARIO_SEM_PERMISSAO.getMensagem(), ex.getMessage());
@@ -678,16 +364,10 @@ class GfdManagerServiceTest {
         inputDto.setCodUsuario(codUsuario);
         inputDto.setFuncionario(funcDto);
 
-        var fornecedorGetByIdDto = new FornecedorGetByIdOutputDto();
-        fornecedorGetByIdDto.setCodigo(codFornecedor);
-        fornecedorGetByIdDto.setCodUsuario(333);
-        when(fornecedorService.getById(codFornecedor)).thenReturn(fornecedorGetByIdDto);
-
         var fornecedorEntity = new Fornecedor();
         fornecedorEntity.setCodigo(codFornecedor);
         fornecedorEntity.setCodUsuario(333);
-        when(modelMapper.map(fornecedorGetByIdDto, Fornecedor.class))
-                .thenReturn(fornecedorEntity);
+        when(getFornecedorByCodOrIdUseCase.execute(codUsuario, codFornecedor)).thenReturn(fornecedorEntity);
 
         // Act
         var ex = assertThrows(ForbiddenException.class, () -> gfdManagerService.getFuncionario(inputDto));
@@ -712,18 +392,11 @@ class GfdManagerServiceTest {
         inputDto.setCodUsuario(codUsuario);
         inputDto.setFuncionario(funcDto);
 
-        var fornecedorGetByIdDto = new FornecedorGetByIdOutputDto();
-        fornecedorGetByIdDto.setCodigo(codFornecedor);
-        fornecedorGetByIdDto.setCodUsuario(codUsuario);
-
-        when(fornecedorService.getById(codFornecedor)).thenReturn(fornecedorGetByIdDto);
-
         var fornecedorEntity = new Fornecedor();
         fornecedorEntity.setCodigo(codFornecedor);
         fornecedorEntity.setCodUsuario(codUsuario);
 
-        when(modelMapper.map(fornecedorGetByIdDto, Fornecedor.class))
-                .thenReturn(fornecedorEntity);
+        when(getFornecedorByCodOrIdUseCase.execute(codUsuario, codFornecedor)).thenReturn(fornecedorEntity);
 
         var funcionarioEntity = new GfdFuncionarioGetAllOutputDto();
         funcionarioEntity.setId(idFuncionario);
@@ -765,16 +438,10 @@ class GfdManagerServiceTest {
         inputDto.setCodUsuario(codUsuario);
         inputDto.setFuncionario(funcDto);
 
-        var fornecedorGetByIdDto = new FornecedorGetByIdOutputDto();
-        fornecedorGetByIdDto.setCodigo(codFornecedor);
-        fornecedorGetByIdDto.setCodUsuario(codUsuario);
-        when(fornecedorService.getById(codFornecedor)).thenReturn(fornecedorGetByIdDto);
-
         var fornecedorEntity = new Fornecedor();
         fornecedorEntity.setCodigo(codFornecedor);
         fornecedorEntity.setCodUsuario(codUsuario);
-        when(modelMapper.map(fornecedorGetByIdDto, Fornecedor.class))
-                .thenReturn(fornecedorEntity);
+        when(getFornecedorByCodOrIdUseCase.execute(codUsuario, codFornecedor)).thenReturn(fornecedorEntity);
 
         var domainDeleteDto = new GfdFuncionarioDeleteInputDto();
         domainDeleteDto.setId(idFuncionario);
@@ -804,16 +471,10 @@ class GfdManagerServiceTest {
         inputDto.setCodUsuario(codUsuario);
         inputDto.setFuncionario(funcDto);
 
-        var fornecedorGetByIdDto = new FornecedorGetByIdOutputDto();
-        fornecedorGetByIdDto.setCodigo(codFornecedor);
-        fornecedorGetByIdDto.setCodUsuario(999); // diferente
-        when(fornecedorService.getById(codFornecedor)).thenReturn(fornecedorGetByIdDto);
-
         var fornecedorEntity = new Fornecedor();
         fornecedorEntity.setCodigo(codFornecedor);
         fornecedorEntity.setCodUsuario(999);
-        when(modelMapper.map(fornecedorGetByIdDto, Fornecedor.class))
-                .thenReturn(fornecedorEntity);
+        when(getFornecedorByCodOrIdUseCase.execute(codUsuario, codFornecedor)).thenReturn(fornecedorEntity);
 
         // Act & Assert
         var ex = assertThrows(ForbiddenException.class, () ->
@@ -848,7 +509,6 @@ class GfdManagerServiceTest {
         var docInput = new GfdMDocumentoUpdateInputDto.GfdDocumentoUpdateInputDto(documentoId, LocalDate.now(), null, statusNaoConforme, "obs");
         input.setDocumento(docInput);
 
-        var docMapped = new GfdDocumentoUpdateInputDto();
         var updated = new GfdDocumentoUpdateOutputDto();
         updated.setId(documentoId);
         updated.setStatus(GfdDocumentoStatusEnum.NAO_CONFORME);
@@ -856,10 +516,8 @@ class GfdManagerServiceTest {
 
         var outputDto = new GfdMDocumentoUpdateOutputDto.GfdDocumentoUpdateOutputDto();
 
-        when(fornecedorService.getById(fornecedorExistenteId)).thenReturn(mock(FornecedorGetByIdOutputDto.class));
-        when(modelMapper.map(any(FornecedorGetByIdOutputDto.class), eq(Fornecedor.class))).thenReturn(fornecedor);
-        when(modelMapper.map(docInput, GfdDocumentoUpdateInputDto.class)).thenReturn(docMapped);
-        when(gfdDocumentoService.update(docMapped)).thenReturn(updated);
+        when(getFornecedorByCodOrIdUseCase.execute(usuarioLogadoId, fornecedorExistenteId)).thenReturn(fornecedor);
+        when(updateGfdDocumentoUseCase.execute(any(GfdDocumentoUpdateInputDto.class))).thenReturn(updated);
         when(modelMapper.map(any(GfdDocumentoUpdateOutputDto.class), eq(GfdMDocumentoUpdateOutputDto.GfdDocumentoUpdateOutputDto.class))).thenReturn(outputDto);
 
         //act
@@ -877,6 +535,12 @@ class GfdManagerServiceTest {
         input.setCodUsuario(null);
         input.setFornecedor(null);
 
+        when(getFornecedorByCodOrIdUseCase.execute(null, null))
+                .thenThrow(new NotFoundException(
+                        GFD_FORNECEDOR_NAO_ENCONTRADO.getMensagem(),
+                        GFD_FORNECEDOR_NAO_ENCONTRADO.getCode()
+                ));
+
         assertThrows(NotFoundException.class, () -> gfdManagerService.updateDocumento(input));
     }
 
@@ -888,7 +552,11 @@ class GfdManagerServiceTest {
         input.setCodUsuario(null);
         input.setFornecedor(new GfdMDocumentoUpdateInputDto.FornecedorDto(fornecedorExistenteId));
 
-        when(fornecedorService.getById(fornecedorExistenteId)).thenReturn(null);
+        when(getFornecedorByCodOrIdUseCase.execute(null, fornecedorExistenteId))
+                .thenThrow(new NotFoundException(
+                        GFD_FORNECEDOR_NAO_ENCONTRADO.getMensagem(),
+                        GFD_FORNECEDOR_NAO_ENCONTRADO.getCode()
+        ));
 
         assertThrows(NotFoundException.class, () -> gfdManagerService.updateDocumento(input));
     }
@@ -901,7 +569,11 @@ class GfdManagerServiceTest {
         input.setCodUsuario(usuarioLogadoId);
         input.setFornecedor(null);
 
-        when(fornecedorService.getByCodUsuario(any())).thenReturn(null);
+        when(getFornecedorByCodOrIdUseCase.execute(usuarioLogadoId, null))
+                .thenThrow(new NotFoundException(
+                        GFD_FORNECEDOR_NAO_ENCONTRADO.getMensagem(),
+                        GFD_FORNECEDOR_NAO_ENCONTRADO.getCode()
+                ));
 
         assertThrows(NotFoundException.class, () -> gfdManagerService.updateDocumento(input));
     }
@@ -909,21 +581,20 @@ class GfdManagerServiceTest {
     @Test
     void test_updateDocumento_deve_lancar_ForbiddenException_quando_usuario_sem_permissao() {
         final Integer fornecedorExistenteId = 77;
-        final Integer usuarioLogadoId = 123;
+        final Integer codUsuario = 999;
         final String emailFornecedor = "fornecedor@mili.com";
 
         Fornecedor fornecedor;
         fornecedor = new Fornecedor();
         fornecedor.setCodigo(fornecedorExistenteId);
-        fornecedor.setCodUsuario(usuarioLogadoId);
+        fornecedor.setCodUsuario(codUsuario + 1);
         fornecedor.setEmail(emailFornecedor);
 
         var input = new GfdMDocumentoUpdateInputDto();
-        input.setCodUsuario(999); // diferente do fornecedor.getCodUsuario()
+        input.setCodUsuario(codUsuario);
         input.setFornecedor(new GfdMDocumentoUpdateInputDto.FornecedorDto(fornecedorExistenteId));
 
-        when(fornecedorService.getById(fornecedorExistenteId)).thenReturn(mock(FornecedorGetByIdOutputDto.class));
-        when(modelMapper.map(any(FornecedorGetByIdOutputDto.class), eq(Fornecedor.class))).thenReturn(fornecedor);
+        when(getFornecedorByCodOrIdUseCase.execute(codUsuario, fornecedorExistenteId)).thenReturn(fornecedor);
 
         assertThrows(ForbiddenException.class, () -> gfdManagerService.updateDocumento(input));
     }
@@ -951,8 +622,7 @@ class GfdManagerServiceTest {
         fornecedor.setCodUsuario(idUsuarioLogado);
         fornecedor.setEmail(emailFornecedor);
 
-        when(fornecedorService.getById(idFornecedor)).thenReturn(fornecedorOutputDto);
-        when(modelMapper.map(fornecedorOutputDto, Fornecedor.class)).thenReturn(fornecedor);
+        when(getFornecedorByCodOrIdUseCase.execute(idUsuarioLogado, idFornecedor)).thenReturn(fornecedor);
         when(modelMapper.map(inputDto, GfdDocumentoDownloadInputDto.class)).thenReturn(downloadInputDto);
         when(gfdDocumentoService.download(downloadInputDto)).thenReturn(downloadOutputDto);
         when(modelMapper.map(downloadOutputDto, GfdMDocumentoDownloadOutputDto.class)).thenReturn(expectedOutputDto);
@@ -987,12 +657,11 @@ class GfdManagerServiceTest {
         var input = new GfdMDocumentoDeleteInputDto(idDocumento, idUsuarioLogado, idFornecedor);
         var deleteDto = new GfdDocumentoDeleteInputDto();
 
-        when(fornecedorService.getById(idFornecedor)).thenReturn(mock(FornecedorGetByIdOutputDto.class));
-        when(modelMapper.map(any(FornecedorGetByIdOutputDto.class), eq(Fornecedor.class))).thenReturn(fornecedor);
+        when(getFornecedorByCodOrIdUseCase.execute(idUsuarioLogado, idFornecedor)).thenReturn(fornecedor);
         when(modelMapper.map(input, GfdDocumentoDeleteInputDto.class)).thenReturn(deleteDto);
 
         gfdManagerService.deleteDocumento(input);
 
-        verify(gfdDocumentoService).delete(deleteDto);
+        verify(deleteGfdDocumentoUseCase).execute(deleteDto);
     }
 }

--- a/src/test/java/br/com/mili/milibackend/gfd/application/service/GfdTipoDocumentoServiceTest.java
+++ b/src/test/java/br/com/mili/milibackend/gfd/application/service/GfdTipoDocumentoServiceTest.java
@@ -67,26 +67,7 @@ class GfdTipoDocumentoServiceTest {
         assertNull(result);
     }
 
-    @SuppressWarnings("unchecked")
-    @Test
-    void testGetAll() {
-        when(repository.findAll((Specification<GfdTipoDocumento>) any(), any(Sort.class)))
-                .thenReturn(List.of(entity));
 
-        GfdTipoDocumentoGetAllOutputDto dto = new GfdTipoDocumentoGetAllOutputDto();
-        dto.setId(1);
-        dto.setNome("Documento");
-
-        when(modelMapper.map(entity, GfdTipoDocumentoGetAllOutputDto.class)).thenReturn(dto);
-
-        GfdTipoDocumentoGetAllInputDto input = new GfdTipoDocumentoGetAllInputDto();
-        input.setNome("Doc");
-
-        var result = service.getAll(input);
-
-        assertEquals(1, result.size());
-        assertEquals("Documento", result.get(0).getNome());
-    }
 
     @Test
     void testCreate() {

--- a/src/test/java/br/com/mili/milibackend/gfd/application/usecases/CreateDocumentoUseCaseImplTest.java
+++ b/src/test/java/br/com/mili/milibackend/gfd/application/usecases/CreateDocumentoUseCaseImplTest.java
@@ -2,6 +2,7 @@ package br.com.mili.milibackend.gfd.application.usecases;
 
 import br.com.mili.milibackend.gfd.application.dto.gfdDocumento.GfdDocumentoCreateInputDto;
 import br.com.mili.milibackend.gfd.application.dto.gfdDocumento.GfdDocumentoCreateOutputDto;
+import br.com.mili.milibackend.gfd.application.usecases.GfdDocumento.CreateGfdDocumentoUseCaseImpl;
 import br.com.mili.milibackend.gfd.domain.entity.GfdDocumento;
 import br.com.mili.milibackend.gfd.infra.repository.gfdDocumento.GfdDocumentoRepository;
 import org.junit.jupiter.api.Test;
@@ -26,7 +27,7 @@ class CreateDocumentoUseCaseImplTest {
     private ModelMapper modelMapper;
 
     @InjectMocks
-    private CreateDocumentoUseCaseImpl useCase;
+    private CreateGfdDocumentoUseCaseImpl useCase;
 
 
     @Test

--- a/src/test/java/br/com/mili/milibackend/gfd/application/usecases/GetAllGfdFuncionarioUseCaseImplTest.java
+++ b/src/test/java/br/com/mili/milibackend/gfd/application/usecases/GetAllGfdFuncionarioUseCaseImplTest.java
@@ -2,6 +2,7 @@ package br.com.mili.milibackend.gfd.application.usecases;
 
 import br.com.mili.milibackend.gfd.application.dto.gfdFuncionario.GfdFuncionarioGetAllInputDto;
 import br.com.mili.milibackend.gfd.application.dto.gfdFuncionario.GfdFuncionarioGetAllOutputDto;
+import br.com.mili.milibackend.gfd.application.usecases.GfdFuncionario.GetAllGfdFuncionarioUseCaseImpl;
 import br.com.mili.milibackend.gfd.infra.projections.GfdFuncionarioStatusProjection;
 import br.com.mili.milibackend.gfd.infra.repository.gfdFuncionario.GfdFuncionarioRepository;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/br/com/mili/milibackend/gfd/application/usecases/GfdDocumento/GetAllSupplierDocumentsUseCaseImplTest.java
+++ b/src/test/java/br/com/mili/milibackend/gfd/application/usecases/GfdDocumento/GetAllSupplierDocumentsUseCaseImplTest.java
@@ -1,0 +1,229 @@
+package br.com.mili.milibackend.gfd.application.usecases.GfdDocumento;
+
+import br.com.mili.milibackend.fornecedor.domain.entity.Fornecedor;
+import br.com.mili.milibackend.fornecedor.domain.usecases.GetFornecedorByCodOrIdUseCase;
+import br.com.mili.milibackend.gfd.application.dto.GfdMDocumentosGetAllInputDto;
+import br.com.mili.milibackend.gfd.application.dto.GfdMDocumentosGetAllOutputDto;
+import br.com.mili.milibackend.gfd.application.dto.gfdDocumento.GfdDocumentoGetAllInputDto;
+import br.com.mili.milibackend.gfd.application.dto.gfdDocumento.GfdDocumentoGetAllOutputDto;
+import br.com.mili.milibackend.gfd.application.dto.gfdTipoDocumento.GfdTipoDocumentoGetAllInputDto;
+import br.com.mili.milibackend.gfd.application.dto.gfdTipoDocumento.GfdTipoDocumentoGetAllOutputDto;
+import br.com.mili.milibackend.gfd.domain.entity.*;
+import br.com.mili.milibackend.gfd.domain.usecases.GetAllGfdDocumentosUseCase;
+import br.com.mili.milibackend.gfd.domain.usecases.GetAllTipoDocumentoUseCase;
+import br.com.mili.milibackend.gfd.infra.repository.GfdDocumentoPeriodoRepository;
+import br.com.mili.milibackend.gfd.infra.repository.GfdTipoDocumentoRepository;
+import br.com.mili.milibackend.shared.page.pagination.MyPage;
+import br.com.mili.milibackend.shared.page.pagination.PageBaseImpl;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.modelmapper.ModelMapper;
+
+import java.time.LocalDate;
+import java.util.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class GetAllSupplierDocumentsUseCaseImplTest {
+
+    @InjectMocks
+    private GetAllSupplierDocumentsUseCaseImpl service;
+
+    @Mock
+    private ModelMapper modelMapper;
+
+    @Mock
+    private GfdDocumentoPeriodoRepository gfdDocumentoPeriodoRepository;
+
+    @Mock
+    private GfdTipoDocumentoRepository gfdTipoDocumentoRepository;
+
+    @Mock
+    private GetAllGfdDocumentosUseCase getAllGfdDocumentosUseCase;
+
+    @Mock
+    private GetAllTipoDocumentoUseCase getAllTipoDocumentoUseCase;
+
+    @Mock
+    private GetFornecedorByCodOrIdUseCase getFornecedorByCodOrIdUseCase;
+
+    private Fornecedor fornecedor;
+    private GfdTipoDocumento tipoDocumento;
+    private GfdMDocumentosGetAllInputDto inputDto;
+    private GfdDocumentoGetAllInputDto mappedInputDto;
+    private MyPage<GfdDocumentoGetAllOutputDto> pageGfdDocumentos;
+    private List<GfdTipoDocumentoGetAllOutputDto> tiposDocumento;
+
+    @BeforeEach
+    void setUp() {
+        fornecedor = Fornecedor.builder()
+                .codigo(123)
+                .build();
+
+        tipoDocumento = new GfdTipoDocumento();
+        tipoDocumento.setId(1);
+        tipoDocumento.setNome("Test Tipo");
+        tipoDocumento.setDiasValidade(30);
+        tipoDocumento.setClassificacao("GERAL");
+
+        inputDto = new GfdMDocumentosGetAllInputDto();
+        inputDto.setCodUsuario(123);
+        inputDto.setTipoDocumentoId(1);
+
+        mappedInputDto = new GfdDocumentoGetAllInputDto();
+        mappedInputDto.setCtforCodigo(123);
+
+        GfdDocumentoGetAllOutputDto documentoOutput = GfdDocumentoGetAllOutputDto.builder()
+                .id(1)
+                .ctforCodigo(123)
+                .nomeArquivo("test.pdf")
+                .build();
+
+        pageGfdDocumentos = new PageBaseImpl<>(Collections.singletonList(documentoOutput), 1, 10, 1L);
+
+        var tipoDto = new GfdTipoDocumentoGetAllOutputDto();
+        tipoDto.setId(1);
+        tipoDto.setNome("Test Tipo");
+        tipoDto.setClassificacao("GERAL");
+        tipoDto.setDiasValidade(180);
+
+        var tipoDto2 = new GfdTipoDocumentoGetAllOutputDto();
+        tipoDto2.setId(2);
+        tipoDto2.setNome("Test Tipo 2");
+        tipoDto2.setClassificacao("COMPETENCIA");
+        tipoDto2.setDiasValidade(30);
+
+        var tipoDto3 = new GfdTipoDocumentoGetAllOutputDto();
+        tipoDto3.setId(3);
+        tipoDto3.setNome("Test Tipo 3");
+        tipoDto3.setClassificacao("GERAL");
+        tipoDto3.setDiasValidade(30);
+
+        tiposDocumento = Arrays.asList(tipoDto, tipoDto2, tipoDto3);
+    }
+
+    @Test
+    void test_GetAllDocumentos__deve_calcular_navegacao_nextDoc_previousDoc_corretamente() {
+        tipoDocumento = new GfdTipoDocumento();
+        tipoDocumento.setId(tiposDocumento.get(1).getId());
+        tipoDocumento.setNome(tiposDocumento.get(1).getNome());
+        tipoDocumento.setDiasValidade(tiposDocumento.get(1).getDiasValidade());
+        tipoDocumento.setClassificacao(tiposDocumento.get(1).getClassificacao());
+
+        inputDto.setTipoDocumentoId(tiposDocumento.get(1).getId());
+
+        when(getFornecedorByCodOrIdUseCase.execute(eq(inputDto.getCodUsuario()), eq(inputDto.getId()))).thenReturn(fornecedor);
+        when(gfdTipoDocumentoRepository.findById(eq(inputDto.getTipoDocumentoId()))).thenReturn(Optional.of(tipoDocumento));
+        when(modelMapper.map(eq(inputDto), eq(GfdDocumentoGetAllInputDto.class))).thenReturn(mappedInputDto);
+        when(getAllGfdDocumentosUseCase.execute(any(GfdDocumentoGetAllInputDto.class))).thenReturn(pageGfdDocumentos);
+
+        GfdMDocumentosGetAllOutputDto.GfdDocumentoDto mappedDto = new GfdMDocumentosGetAllOutputDto.GfdDocumentoDto();
+        mappedDto.setId(1);
+        mappedDto.setCtforCodigo(123);
+        mappedDto.setNomeArquivo("test.pdf");
+        when(modelMapper.map(any(GfdDocumentoGetAllOutputDto.class), eq(GfdMDocumentosGetAllOutputDto.GfdDocumentoDto.class))).thenReturn(mappedDto);
+
+        GfdTipoDocumentoGetAllInputDto tipoInput = new GfdTipoDocumentoGetAllInputDto();
+        tipoInput.setTipo(GfdTipoDocumentoTipoEnum.FORNECEDOR);
+        when(getAllTipoDocumentoUseCase.execute(any(GfdTipoDocumentoGetAllInputDto.class))).thenReturn(tiposDocumento);
+
+        // Act
+        GfdMDocumentosGetAllOutputDto result = service.execute(inputDto);
+
+        // Assert
+        assertEquals(3, result.getNextDoc(), "nextDoc deve ser 3");
+        assertEquals(1, result.getPreviousDoc(), "previousDoc deve ser 1");
+    }
+
+
+
+    @Test
+    void test_deve_retornar_lista_de_documentos_quando_funcionario_estiver_vazio_e_classificao_for_geral() {
+        when(getFornecedorByCodOrIdUseCase.execute(eq(inputDto.getCodUsuario()), eq(inputDto.getId()))).thenReturn(fornecedor);
+        when(gfdTipoDocumentoRepository.findById(eq(inputDto.getTipoDocumentoId()))).thenReturn(Optional.of(tipoDocumento));
+        when(modelMapper.map(eq(inputDto), eq(GfdDocumentoGetAllInputDto.class))).thenReturn(mappedInputDto);
+        when(getAllGfdDocumentosUseCase.execute(any(GfdDocumentoGetAllInputDto.class))).thenReturn(pageGfdDocumentos);
+
+        GfdMDocumentosGetAllOutputDto.GfdDocumentoDto mappedDto = new GfdMDocumentosGetAllOutputDto.GfdDocumentoDto();
+        mappedDto.setId(1);
+        mappedDto.setCtforCodigo(123);
+        mappedDto.setNomeArquivo("test.pdf");
+        when(modelMapper.map(any(GfdDocumentoGetAllOutputDto.class), eq(GfdMDocumentosGetAllOutputDto.GfdDocumentoDto.class))).thenReturn(mappedDto);
+
+        GfdTipoDocumentoGetAllInputDto tipoInput = new GfdTipoDocumentoGetAllInputDto();
+        tipoInput.setTipo(GfdTipoDocumentoTipoEnum.FORNECEDOR);
+        when(getAllTipoDocumentoUseCase.execute(any(GfdTipoDocumentoGetAllInputDto.class))).thenReturn(tiposDocumento);
+
+        // Act
+        GfdMDocumentosGetAllOutputDto result = service.execute(inputDto);
+
+        // Assert
+        assertNotNull(result);
+        assertEquals(1, result.getGfdDocumento().getContent().size());
+        assertEquals("Test Tipo", result.getGfdTipoDocumento().getNome());
+        verify(gfdDocumentoPeriodoRepository, never()).findByGfdDocumento_IdIn(anyList());
+    }
+
+    @Test
+    void teste_deve_retornar_periodo_na_dto_quando_classificacao_for_competencia() {
+        tipoDocumento.setClassificacao(GfdTipoDocumentoTipoClassificacaoEnum.COMPETENCIA.name());
+
+        when(getFornecedorByCodOrIdUseCase.execute(eq(inputDto.getCodUsuario()), eq(inputDto.getId()))).thenReturn(fornecedor);
+        when(gfdTipoDocumentoRepository.findById(eq(inputDto.getTipoDocumentoId()))).thenReturn(Optional.of(tipoDocumento));
+        when(modelMapper.map(eq(inputDto), eq(GfdDocumentoGetAllInputDto.class))).thenReturn(mappedInputDto);
+        when(getAllGfdDocumentosUseCase.execute(any(GfdDocumentoGetAllInputDto.class))).thenReturn(pageGfdDocumentos);
+
+        var mappedDto = new GfdMDocumentosGetAllOutputDto.GfdDocumentoDto();
+        mappedDto.setId(1);
+        mappedDto.setCtforCodigo(123);
+        mappedDto.setNomeArquivo("test.pdf");
+        when(modelMapper.map(any(GfdDocumentoGetAllOutputDto.class), eq(GfdMDocumentosGetAllOutputDto.GfdDocumentoDto.class))).thenReturn(mappedDto);
+
+        GfdDocumentoPeriodo periodo = new GfdDocumentoPeriodo();
+        periodo.setId(1);
+        periodo.setPeriodoFinal(LocalDate.now());
+        periodo.setGfdDocumento(new GfdDocumento());
+        periodo.getGfdDocumento().setId(1);
+
+        when(gfdDocumentoPeriodoRepository.findByGfdDocumento_IdIn(eq(Collections.singletonList(1)))).thenReturn(Collections.singletonList(periodo));
+
+        when(getAllTipoDocumentoUseCase.execute(any(GfdTipoDocumentoGetAllInputDto.class))).thenReturn(tiposDocumento);
+
+        // Act
+        GfdMDocumentosGetAllOutputDto result = service.execute(inputDto);
+
+        // Assert
+        assertNotNull(result);
+        assertNotNull(result.getGfdDocumento().getContent().get(0).getGfdDocumentoPeriodo());
+        verify(gfdDocumentoPeriodoRepository).findByGfdDocumento_IdIn(anyList());
+    }
+
+
+    @Test
+    void teste_deve_retornar_lista_de_documentos_vazia_quando_nao_houver_documentos() {
+        MyPage<GfdDocumentoGetAllOutputDto> emptyPage = new PageBaseImpl<>(new ArrayList<>(), 1, 10, 0L);
+
+        when(getFornecedorByCodOrIdUseCase.execute(eq(inputDto.getCodUsuario()), eq(inputDto.getId()))).thenReturn(fornecedor);
+        when(gfdTipoDocumentoRepository.findById(eq(inputDto.getTipoDocumentoId()))).thenReturn(Optional.of(tipoDocumento));
+        when(modelMapper.map(eq(inputDto), eq(GfdDocumentoGetAllInputDto.class))).thenReturn(mappedInputDto);
+        when(getAllGfdDocumentosUseCase.execute(any(GfdDocumentoGetAllInputDto.class))).thenReturn(emptyPage);
+
+        when(getAllTipoDocumentoUseCase.execute(any(GfdTipoDocumentoGetAllInputDto.class))).thenReturn(tiposDocumento);
+
+        // Act
+        GfdMDocumentosGetAllOutputDto result = service.execute(inputDto);
+
+        // Assert
+        assertNotNull(result);
+        assertTrue(result.getGfdDocumento().getContent().isEmpty());
+        assertEquals(0L, result.getGfdDocumento().getTotalElements());
+    }
+}

--- a/src/test/java/br/com/mili/milibackend/gfd/application/usecases/GfdTipoDocumento/GetAllTipoDocumentoUseCaseImplTest.java
+++ b/src/test/java/br/com/mili/milibackend/gfd/application/usecases/GfdTipoDocumento/GetAllTipoDocumentoUseCaseImplTest.java
@@ -1,0 +1,63 @@
+package br.com.mili.milibackend.gfd.application.usecases.GfdTipoDocumento;
+
+import br.com.mili.milibackend.gfd.application.dto.gfdTipoDocumento.GfdTipoDocumentoGetAllInputDto;
+import br.com.mili.milibackend.gfd.application.dto.gfdTipoDocumento.GfdTipoDocumentoGetAllOutputDto;
+import br.com.mili.milibackend.gfd.domain.entity.GfdTipoDocumento;
+import br.com.mili.milibackend.gfd.infra.repository.GfdTipoDocumentoRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.modelmapper.ModelMapper;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.jpa.domain.Specification;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class GetAllTipoDocumentoUseCaseImplTest {
+    @Mock
+    private GfdTipoDocumentoRepository repository;
+
+    @Mock
+    private ModelMapper modelMapper;
+
+    @InjectMocks
+    private GetAllTipoDocumentoUseCaseImpl service;
+
+    private GfdTipoDocumento entity;
+
+    @BeforeEach
+    void setup() {
+        entity = new GfdTipoDocumento();
+        entity.setId(1);
+        entity.setNome("Documento");
+        entity.setAtivo(true);
+    }
+
+    @Test
+    void teste_GetAll() {
+        when(repository.findAll((Specification<GfdTipoDocumento>) any(), any(Sort.class)))
+                .thenReturn(List.of(entity));
+
+        GfdTipoDocumentoGetAllOutputDto dto = new GfdTipoDocumentoGetAllOutputDto();
+        dto.setId(1);
+        dto.setNome("Documento");
+
+        when(modelMapper.map(entity, GfdTipoDocumentoGetAllOutputDto.class)).thenReturn(dto);
+
+        GfdTipoDocumentoGetAllInputDto input = new GfdTipoDocumentoGetAllInputDto();
+        input.setNome("Doc");
+
+        var result = service.execute(input);
+
+        assertEquals(1, result.size());
+        assertEquals("Documento", result.get(0).getNome());
+    }
+}

--- a/src/test/java/br/com/mili/milibackend/gfd/application/usecases/LiberarFuncionarioUseCaseImplTest.java
+++ b/src/test/java/br/com/mili/milibackend/gfd/application/usecases/LiberarFuncionarioUseCaseImplTest.java
@@ -3,6 +3,7 @@ package br.com.mili.milibackend.gfd.application.usecases;
 import br.com.mili.milibackend.gfd.adapter.exception.GfdFuncionarioCodeException;
 import br.com.mili.milibackend.gfd.application.dto.gfdFuncionario.GfdFuncionarioLiberarInputDto;
 import br.com.mili.milibackend.gfd.application.dto.gfdFuncionario.GfdFuncionarioLiberarOutputDto;
+import br.com.mili.milibackend.gfd.application.usecases.GfdFuncionario.LiberarFuncionarioUseCaseImpl;
 import br.com.mili.milibackend.gfd.domain.entity.GfdFuncionario;
 import br.com.mili.milibackend.gfd.domain.entity.GfdFuncionarioLiberacao;
 import br.com.mili.milibackend.gfd.infra.projections.GfdFuncionarioDocumentsProjection;


### PR DESCRIPTION
📌 Solicitação
-

**43960** – GFD -> incluir filtro por período na tela de Documentos.
**44318** – Retirar acento na hora de salvar os arquivos no banco, podendo assim fazer o download sem problemas

 ✅ Solução
-

**43960** 
- Adicionado novo fluxo para criar períodos nos documentos
- Adicionado no getAll a busca por períodos
- Adicionado no verify Documents a busca por períodos
- Ajustado fluxo do update para criar e apgar os períodos
- Extraido para SupplierGetAll
- Extraído método recuperar fornecedor em use case
- Extraído métodos do GfdTipoDocumentoService (GetAll) em use case
- Extraído métodos do GfdDocumentoService (getAll, update, delete, download) em use case
- Criação dos testes

- Corrigido o verify fornecedor, onde o fornecedor mesmo não estando com o termo lgpd aceito podia mexer no sistema.

**43960** 
- Adicionado normalize no serviço de fileProcessing para remover acentos e caracteres especiais
