### PR TITLE
feat: 44055 implement accept type only pdf in upload docs | feat: 44306 implement multiples user to fornecedor | refactor: extract validatePermission to useCase

### DIFF
--- a/src/main/java/br/com/mili/milibackend/fornecedor/adapter/web/FornecedorController.java
+++ b/src/main/java/br/com/mili/milibackend/fornecedor/adapter/web/FornecedorController.java
@@ -42,7 +42,7 @@ public class FornecedorController {
         return roles.contains(ROLE_ANALISTA);
     }
 
-   @PreAuthorize("hasAuthority('" + ROLE_ANALISTA + "') or hasAuthority('" + ROLE_FORNECEDOR + "')")
+    @PreAuthorize("hasAuthority('" + ROLE_ANALISTA + "') or hasAuthority('" + ROLE_FORNECEDOR + "')")
     @PutMapping
     public ResponseEntity<FornecedorMeusDadosUpdateOutputDto> updateMeusDados(
             @AuthenticationPrincipal CustomUserPrincipal user,
@@ -53,7 +53,9 @@ public class FornecedorController {
         inputDto.setCodUsuario(user.getIdUser());
 
         if (isAnalista(user)) {
-            inputDto.setId(inputDto.getId());
+            inputDto.setCodUsuario(null);
+        } else {
+            inputDto.setId(null);
         }
 
         var fornecedor = fornecedorService.updateMeusDados(inputDto);
@@ -62,7 +64,7 @@ public class FornecedorController {
     }
 
 
-  /// @PreAuthorize("hasAuthority('" + ROLE_ANALISTA + "') or hasAuthority('" + ROLE_FORNECEDOR + "')")
+    /// @PreAuthorize("hasAuthority('" + ROLE_ANALISTA + "') or hasAuthority('" + ROLE_FORNECEDOR + "')")
     @GetMapping
     public ResponseEntity<MyPage<FornecedorGetAllOutputDto>> getAll(
             @ParameterObject @ModelAttribute FornecedorGetAllInputDto inputDto,

--- a/src/main/java/br/com/mili/milibackend/fornecedor/application/usecases/ValidatePermissionFornecedorUseCaseImpl.java
+++ b/src/main/java/br/com/mili/milibackend/fornecedor/application/usecases/ValidatePermissionFornecedorUseCaseImpl.java
@@ -1,0 +1,21 @@
+package br.com.mili.milibackend.fornecedor.application.usecases;
+
+import br.com.mili.milibackend.fornecedor.domain.usecases.ValidatePermissionFornecedorUseCase;
+import br.com.mili.milibackend.fornecedor.infra.repository.fornecedorRepository.FornecedorRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ValidatePermissionFornecedorUseCaseImpl implements ValidatePermissionFornecedorUseCase {
+    private final FornecedorRepository fornecedorRepository;
+
+    @Override
+    public boolean execute(Integer codUsuario, Integer fornecedorId) {
+        // se não vier codUsuario, significa que o utilizador é um analista
+        if (codUsuario == null) return true;
+
+        return fornecedorRepository
+                .existsByUsuarioIdAndFornecedorId(codUsuario, fornecedorId);
+    }
+}

--- a/src/main/java/br/com/mili/milibackend/fornecedor/domain/entity/Fornecedor.java
+++ b/src/main/java/br/com/mili/milibackend/fornecedor/domain/entity/Fornecedor.java
@@ -101,9 +101,6 @@ public class Fornecedor {
     @Column(name = "BLOQUEADO")
     private String bloqueado;
 
-    @Column(name = "CTUSU_CODIGO")
-    private Integer codUsuario;
-
     @OneToMany(mappedBy = "ctforCodigo", fetch = FetchType.LAZY)
     private List<GfdDocumento> documentos;
 }

--- a/src/main/java/br/com/mili/milibackend/fornecedor/domain/usecases/ValidatePermissionFornecedorUseCase.java
+++ b/src/main/java/br/com/mili/milibackend/fornecedor/domain/usecases/ValidatePermissionFornecedorUseCase.java
@@ -1,0 +1,5 @@
+package br.com.mili.milibackend.fornecedor.domain.usecases;
+
+public interface ValidatePermissionFornecedorUseCase {
+    boolean execute(Integer codUsuario, Integer fornecedorId);
+}

--- a/src/main/java/br/com/mili/milibackend/fornecedor/infra/repository/fornecedorRepository/FornecedorRepository.java
+++ b/src/main/java/br/com/mili/milibackend/fornecedor/infra/repository/fornecedorRepository/FornecedorRepository.java
@@ -6,11 +6,26 @@ import br.com.mili.milibackend.fornecedor.domain.interfaces.repository.IForneced
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
 public interface FornecedorRepository extends JpaRepository<Fornecedor, Integer>, JpaSpecificationExecutor<Fornecedor>, IFornecedorCustomRepository {
 
-    @Query("SELECT f FROM Fornecedor f LEFT JOIN FETCH f.documentos d LEFT JOIN FETCH d.gfdTipoDocumento WHERE f.codUsuario = :codUsuario")
-    Optional<Fornecedor> findByCodUsuario(Integer codUsuario);
+    @Query("""
+        SELECT f
+        FROM GfdFornecedorUsuario gfu
+        JOIN gfu.fornecedor f
+        WHERE gfu.id.codUsuario = :codUsuario
+    """)
+    Optional<Fornecedor> findByCodUsuario(@Param("codUsuario") Integer codUsuario);
+
+    @Query("""
+        SELECT CASE WHEN COUNT(fu) > 0 THEN true ELSE false END
+        FROM GfdFornecedorUsuario fu
+        WHERE fu.id.codUsuario = :codUsuario
+          AND fu.id.fornecedorId = :fornecedorId
+    """)
+    boolean existsByUsuarioIdAndFornecedorId(@Param("codUsuario") Integer codUsuario,
+                                             @Param("fornecedorId") Integer fornecedorId);
 }

--- a/src/main/java/br/com/mili/milibackend/gfd/adapter/web/controller/GfdMDocumentoController.java
+++ b/src/main/java/br/com/mili/milibackend/gfd/adapter/web/controller/GfdMDocumentoController.java
@@ -60,8 +60,11 @@ public class GfdMDocumentoController {
         inputDto.setIdFuncionario(idFuncionario);
         inputDto.setPeriodo(periodo);
 
-        if (gfdPolicy.isAnalista(user)) {
+        if (!gfdPolicy.isFornecedor(user)) {
             inputDto.setId(fornecedorId);
+            inputDto.setCodUsuario(null);
+        } else {
+            inputDto.setId(null);
         }
 
         return ResponseEntity.ok(getAllGfdDocumentsStatusUseCaseImpl.execute(inputDto));
@@ -78,10 +81,12 @@ public class GfdMDocumentoController {
 
         if (gfdPolicy.isFornecedor(user)) {
             inputDto.setId(null);
+            inputDto.setCodUsuario(user.getIdUser());
+        } else {
+            inputDto.setCodUsuario(null);
         }
 
         inputDto.setUsuario(user.getUsername());
-        inputDto.setCodUsuario(user.getIdUser());
 
         return ResponseEntity.ok(uploadGfdDocumentoUseCase.execute(inputDto));
     }
@@ -100,7 +105,9 @@ public class GfdMDocumentoController {
         inputDto.setUsuario(user.getUsername());
         inputDto.setCodUsuario(user.getIdUser());
 
-        if (gfdPolicy.isFornecedor(user)) {
+        if (!gfdPolicy.isFornecedor(user)) {
+            inputDto.setCodUsuario(null);
+        } else {
             inputDto.setId(null);
         }
 
@@ -149,8 +156,10 @@ public class GfdMDocumentoController {
         inputDto.setId(id);
         inputDto.setCodUsuario(user.getIdUser());
 
-        if (gfdPolicy.isAnalista(user)) {
+        if (!gfdPolicy.isFornecedor(user)) {
             inputDto.setCodUsuario(null);
+        } else {
+            inputDto.setFornecedorId(null);
         }
 
         gfdManagerService.deleteDocumento(inputDto);
@@ -174,8 +183,10 @@ public class GfdMDocumentoController {
         inputDto.setId(id);
         inputDto.setCodUsuario(user.getIdUser());
 
-        if (gfdPolicy.isAnalista(user)) {
+        if (!gfdPolicy.isFornecedor(user)) {
             inputDto.setCodUsuario(null);
+        } else {
+            inputDto.setFornecedorId(null);
         }
 
         return ResponseEntity.ok(gfdManagerService.downloadDocumento(inputDto));

--- a/src/main/java/br/com/mili/milibackend/gfd/adapter/web/controller/GfdMFuncionarioController.java
+++ b/src/main/java/br/com/mili/milibackend/gfd/adapter/web/controller/GfdMFuncionarioController.java
@@ -55,6 +55,8 @@ public class GfdMFuncionarioController {
 
         if (gfdPolicy.isFornecedor(user)) {
             inputDto.setCodUsuario(user.getIdUser());
+        } else {
+            inputDto.setCodUsuario(null);
         }
 
         return ResponseEntity.ok(gfdManagerService.createFuncionario(inputDto));

--- a/src/main/java/br/com/mili/milibackend/gfd/application/dto/GfdMFuncionarioCreateInputDto.java
+++ b/src/main/java/br/com/mili/milibackend/gfd/application/dto/GfdMFuncionarioCreateInputDto.java
@@ -1,5 +1,8 @@
 package br.com.mili.milibackend.gfd.application.dto;
 
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
 import lombok.*;
 
 import java.time.LocalDate;
@@ -11,7 +14,10 @@ import java.time.LocalDate;
 @NoArgsConstructor
 public class GfdMFuncionarioCreateInputDto {
     private Integer codUsuario;
+    @Valid
     private GfdFuncionarioDto funcionario;
+
+    @Valid
     private GfdDocumentoPeriodoDto gfdDocumentoPeriodo;
 
     @Getter
@@ -21,15 +27,33 @@ public class GfdMFuncionarioCreateInputDto {
     @NoArgsConstructor
     public static class GfdFuncionarioDto {
         private FornecedorDto fornecedor;
+
+        @NotEmpty
         private String nome;
+
+        @NotEmpty
         private String cpf;
+
+        @NotNull
         private LocalDate dataNascimento;
+
+        @NotEmpty
         private String paisNacionalidade;
+
+        @NotEmpty
         private String funcao;
+
+        @NotEmpty
         private String tipoContratacao;
+
+        @NotNull
         private LocalDate periodoInicial;
+
+        @NotNull
         private LocalDate periodoFinal;
+
         private String observacao;
+
         private Integer ativo;
 
         @AllArgsConstructor
@@ -46,6 +70,7 @@ public class GfdMFuncionarioCreateInputDto {
     @Getter
     @Setter
     public static class GfdDocumentoPeriodoDto {
+
         private LocalDate periodo;
     }
 }

--- a/src/main/java/br/com/mili/milibackend/gfd/application/dto/GfdMFuncionarioUpdateInputDto.java
+++ b/src/main/java/br/com/mili/milibackend/gfd/application/dto/GfdMFuncionarioUpdateInputDto.java
@@ -1,5 +1,8 @@
 package br.com.mili.milibackend.gfd.application.dto;
 
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
 import lombok.*;
 
 import java.time.LocalDate;
@@ -11,6 +14,8 @@ import java.time.LocalDate;
 @NoArgsConstructor
 public class GfdMFuncionarioUpdateInputDto {
     private Integer codUsuario;
+
+    @Valid
     private GfdFuncionarioDto funcionario;
 
     @Getter
@@ -21,14 +26,31 @@ public class GfdMFuncionarioUpdateInputDto {
     public static class GfdFuncionarioDto {
         private Integer id;
         private FornecedorDto fornecedor;
+
+        @NotEmpty
         private String nome;
+
+        @NotEmpty
         private String cpf;
+
+        @NotNull
         private LocalDate dataNascimento;
+
+        @NotEmpty
         private String paisNacionalidade;
+
+        @NotEmpty
         private String funcao;
+
+        @NotEmpty
         private String tipoContratacao;
+
+        @NotNull
         private LocalDate periodoInicial;
+
+        @NotNull
         private LocalDate periodoFinal;
+
         private String observacao;
 
 

--- a/src/main/java/br/com/mili/milibackend/gfd/application/usecases/GfdDocumento/UploadGfdDocumentoUseCaseImpl.java
+++ b/src/main/java/br/com/mili/milibackend/gfd/application/usecases/GfdDocumento/UploadGfdDocumentoUseCaseImpl.java
@@ -16,6 +16,7 @@ import br.com.mili.milibackend.gfd.domain.usecases.CreateDocumentoPeriodoUseCase
 import br.com.mili.milibackend.gfd.domain.usecases.CreateDocumentoUseCase;
 import br.com.mili.milibackend.gfd.domain.usecases.UploadGfdDocumentoUseCase;
 import br.com.mili.milibackend.gfd.infra.repository.GfdTipoDocumentoRepository;
+import br.com.mili.milibackend.shared.enums.MimeTypeEnum;
 import br.com.mili.milibackend.shared.exception.types.BadRequestException;
 import br.com.mili.milibackend.shared.exception.types.NotFoundException;
 import br.com.mili.milibackend.shared.infra.aws.IS3Service;
@@ -56,7 +57,7 @@ public class UploadGfdDocumentoUseCaseImpl implements UploadGfdDocumentoUseCase 
 
         validarCompatibilidadeTipoDocumento(inputDto, tipoDocumento);
 
-        DocumentoFileData documentoFileData = fileProcessingService.processFile(base64File, base64FileName);
+        DocumentoFileData documentoFileData = fileProcessingService.processFile(base64File, base64FileName, MimeTypeEnum.PDF);
 
         var gfdDocumentoCreateOutputDto = createGfdDocumento(inputDto, tipoDocumento, fornecedor, documentoFileData, gfdDocumentoDto, base64File);
 

--- a/src/main/java/br/com/mili/milibackend/gfd/domain/entity/GfdFornecedorUsuario.java
+++ b/src/main/java/br/com/mili/milibackend/gfd/domain/entity/GfdFornecedorUsuario.java
@@ -1,0 +1,28 @@
+package br.com.mili.milibackend.gfd.domain.entity;
+
+import br.com.mili.milibackend.fornecedor.domain.entity.Fornecedor;
+import br.com.mili.milibackend.user.domain.entity.User;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "GFD_FORNECEDOR_USUARIO")
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class GfdFornecedorUsuario {
+
+    @EmbeddedId
+    private GfdFornecedorUsuarioPk id;
+
+    @ManyToOne
+    @MapsId("codUsuario")
+    @JoinColumn(name = "CTUSU_CODIGO")
+    private User usuario;
+
+    @ManyToOne
+    @MapsId("fornecedorId")
+    @JoinColumn(name = "CTFOR_CODIGO")
+    private Fornecedor fornecedor;
+}

--- a/src/main/java/br/com/mili/milibackend/gfd/domain/entity/GfdFornecedorUsuarioPk.java
+++ b/src/main/java/br/com/mili/milibackend/gfd/domain/entity/GfdFornecedorUsuarioPk.java
@@ -1,0 +1,12 @@
+package br.com.mili.milibackend.gfd.domain.entity;
+
+import jakarta.persistence.Embeddable;
+import lombok.*;
+
+@Embeddable
+@Data
+@NoArgsConstructor
+public class GfdFornecedorUsuarioPk {
+    private Integer codUsuario;
+    private Integer fornecedorId;
+}

--- a/src/main/java/br/com/mili/milibackend/gfd/domain/interfaces/FileProcessingService.java
+++ b/src/main/java/br/com/mili/milibackend/gfd/domain/interfaces/FileProcessingService.java
@@ -1,7 +1,8 @@
 package br.com.mili.milibackend.gfd.domain.interfaces;
 
 import br.com.mili.milibackend.gfd.application.dto.fileprocess.DocumentoFileData;
+import br.com.mili.milibackend.shared.enums.MimeTypeEnum;
 
 public interface FileProcessingService {
-    DocumentoFileData processFile(String base64File, String originalFileName);
+    DocumentoFileData processFile(String base64File, String originalFileName, MimeTypeEnum allowedMimeTypes);
 }

--- a/src/main/java/br/com/mili/milibackend/gfd/infra/fileprocess/exception/FileProcessingException.java
+++ b/src/main/java/br/com/mili/milibackend/gfd/infra/fileprocess/exception/FileProcessingException.java
@@ -1,0 +1,14 @@
+package br.com.mili.milibackend.gfd.infra.fileprocess.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+@AllArgsConstructor
+@Getter
+public enum FileProcessingException {
+    FILE_PROCESSING_TYPE_NOT_PERMITED("FILE_PROCESSING_TYPE_NOT_PERMITED", "Tipo de arquivo não permitido. Arquivos permitidos: ");
+
+    private final String code;
+    private final String mensagem;
+
+}
+

--- a/src/main/java/br/com/mili/milibackend/shared/enums/MimeTypeEnum.java
+++ b/src/main/java/br/com/mili/milibackend/shared/enums/MimeTypeEnum.java
@@ -4,10 +4,12 @@ import lombok.Getter;
 
 @Getter
 public enum MimeTypeEnum {
+        ALL("*/*"),
         JPEG("image/jpeg"),
         PNG("image/png"),
         PDF("application/pdf"),
-        MP4("video/mp4");
+        MP4("video/mp4"),
+        IMAGE("image/*");
 
         private final String contentType;
 

--- a/src/test/java/br/com/mili/milibackend/fornecedor/application/service/FornecedorServiceTest.java
+++ b/src/test/java/br/com/mili/milibackend/fornecedor/application/service/FornecedorServiceTest.java
@@ -2,6 +2,7 @@ package br.com.mili.milibackend.fornecedor.application.service;
 
 import br.com.mili.milibackend.fornecedor.application.dto.*;
 import br.com.mili.milibackend.fornecedor.domain.entity.Fornecedor;
+import br.com.mili.milibackend.fornecedor.domain.usecases.ValidatePermissionFornecedorUseCase;
 import br.com.mili.milibackend.fornecedor.infra.dto.FornecedorResumoDto;
 import br.com.mili.milibackend.fornecedor.infra.repository.fornecedorRepository.FornecedorRepository;
 import br.com.mili.milibackend.shared.exception.types.NotFoundException;
@@ -39,13 +40,15 @@ class FornecedorServiceTest {
     @Mock
     private ModelMapper modelMapper;
 
+    @Mock
+    private ValidatePermissionFornecedorUseCase validatePermissionFornecedorUseCase;
+
     @Test
     void test_GetByCodUsuario__deveRetornarFornecedor_quandoEncontrado() {
         var input = new FornecedorGetByCodUsuarioInputDto();
         input.setCodUsuario(123);
 
         var entity = new Fornecedor();
-        entity.setCodUsuario(123);
         entity.setRazaoSocial("Teste");
 
         var dto = new FornecedorGetByCodUsuarioOutputDto();
@@ -100,6 +103,7 @@ class FornecedorServiceTest {
 
         assertNull(result);
     }
+
     @Test
     void test_UpdateMeusDados__deveAtualizarPorId_quandoExistir() {
         // Arrange
@@ -113,16 +117,13 @@ class FornecedorServiceTest {
         var entity = new Fornecedor();
         entity.setCodigo(1);
         entity.setRazaoSocial("Antiga");
-        entity.setCodUsuario(999);
 
         var outputDto = new FornecedorMeusDadosUpdateOutputDto();
         outputDto.setRazaoSocial("Antiga");
 
         when(fornecedorRepository.findById(1)).thenReturn(Optional.of(entity));
 
-        TypeMap<FornecedorMeusDadosUpdateInputDto, Fornecedor> typeMap = mock(TypeMap.class);
-        when(modelMapper.getTypeMap(FornecedorMeusDadosUpdateInputDto.class, Fornecedor.class)).thenReturn(typeMap);
-        doNothing().when(typeMap).map(any(), any());
+        when(validatePermissionFornecedorUseCase.execute(any(), any())).thenReturn(true);
 
         when(fornecedorRepository.save(entity)).thenReturn(entity);
         when(modelMapper.map(entity, FornecedorMeusDadosUpdateOutputDto.class)).thenReturn(outputDto);
@@ -134,7 +135,6 @@ class FornecedorServiceTest {
         assertNotNull(result);
         assertEquals("Antiga", result.getRazaoSocial());
         verify(fornecedorRepository).save(entity);
-        verify(typeMap).map(input, entity);
         verify(modelMapper).map(entity, FornecedorMeusDadosUpdateOutputDto.class);
     }
 
@@ -147,18 +147,14 @@ class FornecedorServiceTest {
         input.setCelular("987654321");
 
         var entity = new Fornecedor();
-        entity.setCodUsuario(123);
 
         var outputDto = new FornecedorMeusDadosUpdateOutputDto();
 
         when(fornecedorRepository.findByCodUsuario(123)).thenReturn(Optional.of(entity));
 
-        TypeMap<FornecedorMeusDadosUpdateInputDto, Fornecedor> typeMap = mock(TypeMap.class);
-        when(modelMapper.getTypeMap(FornecedorMeusDadosUpdateInputDto.class, Fornecedor.class)).thenReturn(typeMap);
-        doNothing().when(typeMap).map(any(), any());
-
         when(fornecedorRepository.save(entity)).thenReturn(entity);
         when(modelMapper.map(entity, FornecedorMeusDadosUpdateOutputDto.class)).thenReturn(outputDto);
+        when(validatePermissionFornecedorUseCase.execute(any(), any())).thenReturn(true);
 
         var result = fornecedorService.updateMeusDados(input);
 

--- a/src/test/java/br/com/mili/milibackend/fornecedor/application/usecases/GetFornecedorByCodOrIdUseCaseImplTest.java
+++ b/src/test/java/br/com/mili/milibackend/fornecedor/application/usecases/GetFornecedorByCodOrIdUseCaseImplTest.java
@@ -31,7 +31,6 @@ class GetFornecedorByCodOrIdUseCaseImplTest {
     public void setUp() {
         fornecedor = new Fornecedor();
         fornecedor.setCodigo(1);
-        fornecedor.setCodUsuario(1);
         fornecedor.setRazaoSocial("Fornecedor 1");
     }
 

--- a/src/test/java/br/com/mili/milibackend/gfd/application/service/GfdManagerServiceTest.java
+++ b/src/test/java/br/com/mili/milibackend/gfd/application/service/GfdManagerServiceTest.java
@@ -6,6 +6,7 @@ import br.com.mili.milibackend.fornecedor.application.dto.FornecedorGetByIdOutpu
 import br.com.mili.milibackend.fornecedor.domain.entity.Fornecedor;
 import br.com.mili.milibackend.fornecedor.domain.interfaces.service.IFornecedorService;
 import br.com.mili.milibackend.fornecedor.domain.usecases.GetFornecedorByCodOrIdUseCase;
+import br.com.mili.milibackend.fornecedor.domain.usecases.ValidatePermissionFornecedorUseCase;
 import br.com.mili.milibackend.gfd.application.dto.*;
 import br.com.mili.milibackend.gfd.application.dto.gfdDocumento.*;
 import br.com.mili.milibackend.gfd.application.dto.gfdFuncionario.*;
@@ -56,6 +57,9 @@ class GfdManagerServiceTest {
 
     @Mock
     private IGfdDocumentoService gfdDocumentoService;
+
+    @Mock
+    private ValidatePermissionFornecedorUseCase validatePermissionFornecedorUseCase;
 
     @Mock
     private ModelMapper modelMapper;
@@ -151,7 +155,7 @@ class GfdManagerServiceTest {
         fornecedor.setEmail("email@teste.com");
         fornecedor.setCelular("123456789");
         fornecedor.setAceiteLgpd(0);
-        fornecedor.setCodUsuario(123);
+
 
         when(getFornecedorByCodOrIdUseCase.execute(123, null)).thenReturn(fornecedor);
 
@@ -175,7 +179,7 @@ class GfdManagerServiceTest {
         fornecedor.setEmail("email@teste.com");
         fornecedor.setCelular("123456789");
         fornecedor.setAceiteLgpd(0);
-        fornecedor.setCodUsuario(123);
+
 
         when(getFornecedorByCodOrIdUseCase.execute(null, 1)).thenReturn(fornecedor);
         when(modelMapper.map(fornecedor, GfdMFornecedorGetOutputDto.class)).thenReturn(new GfdMFornecedorGetOutputDto());
@@ -209,7 +213,7 @@ class GfdManagerServiceTest {
         // Fornecedor mapeado
         Fornecedor fornecedor = new Fornecedor();
         fornecedor.setCodigo(codFornecedor);
-        fornecedor.setCodUsuario(codUsuario);
+
 
         // Funcionário de entrada para o service de domínio
         GfdFuncionarioCreateInputDto funcionarioCreateInputDto = new GfdFuncionarioCreateInputDto();
@@ -232,6 +236,7 @@ class GfdManagerServiceTest {
         when(modelMapper.map(funcionarioInputDto, GfdFuncionarioCreateInputDto.class)).thenReturn(new GfdFuncionarioCreateInputDto());
         when(gfdFuncionarioService.create(any())).thenReturn(funcionarioCriado);
         when(modelMapper.map(funcionarioCriado, GfdMFuncionarioCreateOutputDto.GfdFuncionarioDto.class)).thenReturn(funcionarioOutputDto);
+        when(validatePermissionFornecedorUseCase.execute(any(), any())).thenReturn(true);
 
         // Act
         var output = gfdManagerService.createFuncionario(inputDto);
@@ -260,8 +265,8 @@ class GfdManagerServiceTest {
 
         var fornecedorEntity = new Fornecedor();
         fornecedorEntity.setCodigo(codFornecedor);
-        fornecedorEntity.setCodUsuario(333);
         when(getFornecedorByCodOrIdUseCase.execute(codUsuario, codFornecedor)).thenReturn(fornecedorEntity);
+        when(validatePermissionFornecedorUseCase.execute(any(), any())).thenReturn(false);
 
         // Act
         var ex = assertThrows(ForbiddenException.class, () -> gfdManagerService.createFuncionario(inputDto));
@@ -288,7 +293,6 @@ class GfdManagerServiceTest {
 
         var fornecedorEntity = new Fornecedor();
         fornecedorEntity.setCodigo(codFornecedor);
-        fornecedorEntity.setCodUsuario(codUsuario);
         when(getFornecedorByCodOrIdUseCase.execute(codUsuario, codFornecedor)).thenReturn(fornecedorEntity);
 
 
@@ -309,6 +313,8 @@ class GfdManagerServiceTest {
         outFuncDto.setNome("Maria Atualizada");
         when(modelMapper.map(domainOutputDto, GfdMFuncionarioUpdateOutputDto.GfdFuncionarioDto.class))
                 .thenReturn(outFuncDto);
+
+        when(validatePermissionFornecedorUseCase.execute(any(), any())).thenReturn(true);
 
         // Act
         var result = gfdManagerService.updateFuncionario(inputDto);
@@ -339,8 +345,9 @@ class GfdManagerServiceTest {
 
         var fornecedorEntity = new Fornecedor();
         fornecedorEntity.setCodigo(codFornecedor);
-        fornecedorEntity.setCodUsuario(333);
         when(getFornecedorByCodOrIdUseCase.execute(codUsuario, codFornecedor)).thenReturn(fornecedorEntity);
+
+        when(validatePermissionFornecedorUseCase.execute(any(), any())).thenReturn(false);
         // Act
         var ex = assertThrows(ForbiddenException.class, () -> gfdManagerService.updateFuncionario(inputDto));
         assertEquals(GFD_FUNCIONARIO_SEM_PERMISSAO.getMensagem(), ex.getMessage());
@@ -366,9 +373,9 @@ class GfdManagerServiceTest {
 
         var fornecedorEntity = new Fornecedor();
         fornecedorEntity.setCodigo(codFornecedor);
-        fornecedorEntity.setCodUsuario(333);
         when(getFornecedorByCodOrIdUseCase.execute(codUsuario, codFornecedor)).thenReturn(fornecedorEntity);
 
+        when(validatePermissionFornecedorUseCase.execute(any(), any())).thenReturn(false);
         // Act
         var ex = assertThrows(ForbiddenException.class, () -> gfdManagerService.getFuncionario(inputDto));
         assertEquals(GFD_FUNCIONARIO_SEM_PERMISSAO.getMensagem(), ex.getMessage());
@@ -394,14 +401,13 @@ class GfdManagerServiceTest {
 
         var fornecedorEntity = new Fornecedor();
         fornecedorEntity.setCodigo(codFornecedor);
-        fornecedorEntity.setCodUsuario(codUsuario);
 
         when(getFornecedorByCodOrIdUseCase.execute(codUsuario, codFornecedor)).thenReturn(fornecedorEntity);
+        when(validatePermissionFornecedorUseCase.execute(any(), any())).thenReturn(true);
 
         var funcionarioEntity = new GfdFuncionarioGetAllOutputDto();
         funcionarioEntity.setId(idFuncionario);
         funcionarioEntity.setNome("Maria");
-
 
         when(getAllGfdFuncionarioUseCase.execute(any(GfdFuncionarioGetAllInputDto.class))).thenReturn(new PageBaseImpl<GfdFuncionarioGetAllOutputDto>(List.of(funcionarioEntity), 1, 20, 0));
 
@@ -440,13 +446,13 @@ class GfdManagerServiceTest {
 
         var fornecedorEntity = new Fornecedor();
         fornecedorEntity.setCodigo(codFornecedor);
-        fornecedorEntity.setCodUsuario(codUsuario);
         when(getFornecedorByCodOrIdUseCase.execute(codUsuario, codFornecedor)).thenReturn(fornecedorEntity);
 
         var domainDeleteDto = new GfdFuncionarioDeleteInputDto();
         domainDeleteDto.setId(idFuncionario);
         when(modelMapper.map(funcDto, GfdFuncionarioDeleteInputDto.class))
                 .thenReturn(domainDeleteDto);
+        when(validatePermissionFornecedorUseCase.execute(any(), any())).thenReturn(true);
 
         // Act
         gfdManagerService.deleteFuncionario(inputDto);
@@ -473,8 +479,8 @@ class GfdManagerServiceTest {
 
         var fornecedorEntity = new Fornecedor();
         fornecedorEntity.setCodigo(codFornecedor);
-        fornecedorEntity.setCodUsuario(999);
         when(getFornecedorByCodOrIdUseCase.execute(codUsuario, codFornecedor)).thenReturn(fornecedorEntity);
+        when(validatePermissionFornecedorUseCase.execute(any(), any())).thenReturn(false);
 
         // Act & Assert
         var ex = assertThrows(ForbiddenException.class, () ->
@@ -499,7 +505,7 @@ class GfdManagerServiceTest {
         Fornecedor fornecedor;
         fornecedor = new Fornecedor();
         fornecedor.setCodigo(fornecedorExistenteId);
-        fornecedor.setCodUsuario(usuarioLogadoId);
+
         fornecedor.setEmail(emailFornecedor);
 
         var input = new GfdMDocumentoUpdateInputDto();
@@ -519,6 +525,7 @@ class GfdManagerServiceTest {
         when(getFornecedorByCodOrIdUseCase.execute(usuarioLogadoId, fornecedorExistenteId)).thenReturn(fornecedor);
         when(updateGfdDocumentoUseCase.execute(any(GfdDocumentoUpdateInputDto.class))).thenReturn(updated);
         when(modelMapper.map(any(GfdDocumentoUpdateOutputDto.class), eq(GfdMDocumentoUpdateOutputDto.GfdDocumentoUpdateOutputDto.class))).thenReturn(outputDto);
+        when(validatePermissionFornecedorUseCase.execute(any(), any())).thenReturn(true);
 
         //act
         var result = gfdManagerService.updateDocumento(input);
@@ -540,6 +547,7 @@ class GfdManagerServiceTest {
                         GFD_FORNECEDOR_NAO_ENCONTRADO.getMensagem(),
                         GFD_FORNECEDOR_NAO_ENCONTRADO.getCode()
                 ));
+
 
         assertThrows(NotFoundException.class, () -> gfdManagerService.updateDocumento(input));
     }
@@ -587,7 +595,6 @@ class GfdManagerServiceTest {
         Fornecedor fornecedor;
         fornecedor = new Fornecedor();
         fornecedor.setCodigo(fornecedorExistenteId);
-        fornecedor.setCodUsuario(codUsuario + 1);
         fornecedor.setEmail(emailFornecedor);
 
         var input = new GfdMDocumentoUpdateInputDto();
@@ -619,13 +626,14 @@ class GfdManagerServiceTest {
 
         var fornecedor = new Fornecedor();
         fornecedor.setCodigo(idFornecedor);
-        fornecedor.setCodUsuario(idUsuarioLogado);
+
         fornecedor.setEmail(emailFornecedor);
 
         when(getFornecedorByCodOrIdUseCase.execute(idUsuarioLogado, idFornecedor)).thenReturn(fornecedor);
         when(modelMapper.map(inputDto, GfdDocumentoDownloadInputDto.class)).thenReturn(downloadInputDto);
         when(gfdDocumentoService.download(downloadInputDto)).thenReturn(downloadOutputDto);
         when(modelMapper.map(downloadOutputDto, GfdMDocumentoDownloadOutputDto.class)).thenReturn(expectedOutputDto);
+        when(validatePermissionFornecedorUseCase.execute(any(), any())).thenReturn(true);
 
         // Act
         var resultado = gfdManagerService.downloadDocumento(inputDto);
@@ -651,7 +659,7 @@ class GfdManagerServiceTest {
 
         var fornecedor = new Fornecedor();
         fornecedor.setCodigo(idFornecedor);
-        fornecedor.setCodUsuario(idUsuarioLogado);
+
         fornecedor.setEmail(emailFornecedor);
 
         var input = new GfdMDocumentoDeleteInputDto(idDocumento, idUsuarioLogado, idFornecedor);
@@ -659,6 +667,7 @@ class GfdManagerServiceTest {
 
         when(getFornecedorByCodOrIdUseCase.execute(idUsuarioLogado, idFornecedor)).thenReturn(fornecedor);
         when(modelMapper.map(input, GfdDocumentoDeleteInputDto.class)).thenReturn(deleteDto);
+        when(validatePermissionFornecedorUseCase.execute(any(), any())).thenReturn(true);
 
         gfdManagerService.deleteDocumento(input);
 

--- a/src/test/java/br/com/mili/milibackend/gfd/application/usecases/UploadGfdDocumentoUseCaseImplTest.java
+++ b/src/test/java/br/com/mili/milibackend/gfd/application/usecases/UploadGfdDocumentoUseCaseImplTest.java
@@ -112,7 +112,7 @@ class UploadGfdDocumentoUseCaseImplTest {
         when(gfdTipoDocumentoRepository.findById(10)).thenReturn(Optional.of(tipoDocumento));
 
         var documentoFileData = new DocumentoFileData("bytes" .getBytes(), "application/pdf", "documento.pdf", 1234);
-        when(fileProcessingService.processFile(anyString(), anyString())).thenReturn(documentoFileData);
+        when(fileProcessingService.processFile(anyString(), anyString(), any())).thenReturn(documentoFileData);
 
         var createOutputDto = new GfdDocumentoCreateOutputDto();
         createOutputDto.setId(10);


### PR DESCRIPTION
📌 Solicitação
-

**CODIGO** – Descrição da solicitação.

**44055** – GFD - Favor deixar somente a opção de anexar ARQUIVO PDF.
**44306** – Criar possibilidade de vincular vários usuários a um fornecedor

 ✅ Solução
-

**44055** 
- Adicionado no fileprocessing tipos requeridos
- Adicionado no serviço de upload docs tipos requeridos como apenas pdf.

**44306** 
- Ajustado as rotas para não deixar um usuário que seja fornecedor acessar outro fornecedor
- Criado usecase para fazer validação do fornecedor
