### PR TITLE
fix: 44459 removed condition that blocked filtering when in the same month | fix: null check added for period | fix: corrected period creation when using day 31 in months without 31 days

### DIFF
--- a/src/main/java/br/com/mili/milibackend/gfd/application/usecases/DocumentoPeriodo/CreateDocumentoPeriodoUseCaseImpl.java
+++ b/src/main/java/br/com/mili/milibackend/gfd/application/usecases/DocumentoPeriodo/CreateDocumentoPeriodoUseCaseImpl.java
@@ -12,6 +12,7 @@ import org.modelmapper.ModelMapper;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDate;
+import java.time.temporal.TemporalAdjusters;
 
 import static br.com.mili.milibackend.gfd.adapter.exception.GfdMCodeException.GFD_PERIODO_VAZIO;
 import static br.com.mili.milibackend.gfd.domain.entity.GfdTipoDocumentoTipoClassificacaoEnum.COMPETENCIA;
@@ -64,7 +65,7 @@ public class CreateDocumentoPeriodoUseCaseImpl implements CreateDocumentoPeriodo
         } else {
             // competencia
             // - pega o valor por meio do input e cria os registros
-            if (gfdDocumentoPeriodoDto == null) {
+            if (gfdDocumentoPeriodoDto == null || gfdDocumentoPeriodoDto.getPeriodo() == null) {
                 throw new BadRequestException(GFD_PERIODO_VAZIO.getMensagem(), GFD_PERIODO_VAZIO.getCode());
             }
             var primeiroPeriodo = gfdDocumentoPeriodoDto.getPeriodo().withDayOfMonth(1);
@@ -92,7 +93,7 @@ public class CreateDocumentoPeriodoUseCaseImpl implements CreateDocumentoPeriodo
     private LocalDate ultimoPeriodo(GfdDocumentoPeriodoCreateInputDto inputDto, GfdDocumentoPeriodoCreateInputDto.GfdDocumentoDto gfdDocumentoDto, int qtdPeriodos) {
         var ultimoPeriodo = gfdDocumentoDto.getDataEmissao()
                 .plusMonths(qtdPeriodos == 1 ? qtdPeriodos : qtdPeriodos - 1)
-                .withDayOfMonth(gfdDocumentoDto.getDataEmissao().plusMonths(qtdPeriodos).lengthOfMonth());
+                .with(TemporalAdjusters.lastDayOfMonth());
 
         if (inputDto.getGfdDocumentoDto().getDataValidade() != null) {
             ultimoPeriodo = inputDto.getGfdDocumentoDto().getDataValidade().withDayOfMonth(inputDto.getGfdDocumentoDto().getDataValidade().lengthOfMonth());

--- a/src/main/java/br/com/mili/milibackend/gfd/application/usecases/GfdDocumento/GetAllSupplierDocumentsUseCaseImpl.java
+++ b/src/main/java/br/com/mili/milibackend/gfd/application/usecases/GfdDocumento/GetAllSupplierDocumentsUseCaseImpl.java
@@ -84,13 +84,6 @@ public class GetAllSupplierDocumentsUseCaseImpl implements GetAllSupplierDocumen
         var gfdDocumentoGetAllInputDto = modelMapper.map(inputDto, GfdDocumentoGetAllInputDto.class);
         gfdDocumentoGetAllInputDto.setCtforCodigo(fornecedor.getCodigo());
 
-        var periodo = gfdDocumentoGetAllInputDto.getPeriodo();
-        var dataAtual = LocalDate.now().withDayOfMonth(1);
-
-        if (periodo != null && periodo.withDayOfMonth(1).equals(dataAtual)) {
-            gfdDocumentoGetAllInputDto.setPeriodo(null);
-        }
-
         var pageGfdDocumentoService = getAllGfdDocumentosUseCase.execute(gfdDocumentoGetAllInputDto);
 
         var gfdDocumentoDto = pageGfdDocumentoService.getContent().stream().map(gfdDocumento -> {

--- a/src/main/java/br/com/mili/milibackend/gfd/application/usecases/GfdDocumento/UploadGfdDocumentoUseCaseImpl.java
+++ b/src/main/java/br/com/mili/milibackend/gfd/application/usecases/GfdDocumento/UploadGfdDocumentoUseCaseImpl.java
@@ -113,7 +113,8 @@ public class UploadGfdDocumentoUseCaseImpl implements UploadGfdDocumentoUseCase 
 
         var gfdDocumentoInputDto = GfdDocumentoCreateInputDto.GfdDocumentoDto.builder()
                 .ctforCodigo(fornecedor.getCodigo())
-                .nomeArquivo(documentoFileData.getNomeArquivo()).nomeArquivoPath("gfd/" + documentoFileData.getNomeArquivo())
+                .nomeArquivo(documentoFileData.getNomeArquivo())
+                .nomeArquivoPath("gfd/" + documentoFileData.getNomeArquivo())
                 .tamanhoArquivo(documentoFileData.getTamanho())
                 .dataCadastro(LocalDate.now())
                 .tipoArquivo(documentoFileData.getMimeType())


### PR DESCRIPTION
📌 Solicitação
-

**44459** – Quando não tiver nenhum período selecionado, favor a tela em branco até que um período seja selecionado

 ✅ Solução
-

**44459** 
- Havia um problema na geração dos períodos: o código tentava definir o último dia do mês assumindo que todos os meses possuem 31 dias, o que causava erros em meses com menos dias (como fevereiro, abril, junho etc.)
- Foi removido a condição que bloqueava o filtro quando era do mesmo mês.
- Foi adicionado mais uma condição do período para verificar se o valor é null.


