### PR TITLE
fix: 44506 - problem in creation period because get dias is null | refactor: 44493 rename PJ to SubContratados

### DIFF
--- a/src/main/java/br/com/mili/milibackend/gfd/application/usecases/DocumentoPeriodo/CreateDocumentoPeriodoUseCaseImpl.java
+++ b/src/main/java/br/com/mili/milibackend/gfd/application/usecases/DocumentoPeriodo/CreateDocumentoPeriodoUseCaseImpl.java
@@ -41,10 +41,12 @@ public class CreateDocumentoPeriodoUseCaseImpl implements CreateDocumentoPeriodo
 
         if (isGeral) {
             final int UM_MES_EN_DIAS = 30;
+            final int UM_ANO = 30 * 12;
+            final int DEZ_ANOS = 10 * UM_ANO;
 
             int diasValidade = tipoDocumentoDto.getDiasValidade() != null
-                    ? tipoDocumentoDto.getDiasValidade()
-                    : UM_MES_EN_DIAS;
+                    ? tipoDocumentoDto.getDiasValidade() / UM_MES_EN_DIAS
+                    : DEZ_ANOS;
 
             int qtdPeriodos = (int) Math.ceil(diasValidade);
 

--- a/src/main/java/br/com/mili/milibackend/gfd/application/usecases/DocumentoPeriodo/CreateDocumentoPeriodoUseCaseImpl.java
+++ b/src/main/java/br/com/mili/milibackend/gfd/application/usecases/DocumentoPeriodo/CreateDocumentoPeriodoUseCaseImpl.java
@@ -42,7 +42,10 @@ public class CreateDocumentoPeriodoUseCaseImpl implements CreateDocumentoPeriodo
         if (isGeral) {
             final int UM_MES_EN_DIAS = 30;
 
-            var diasValidade = (tipoDocumentoDto.getDiasValidade() / UM_MES_EN_DIAS);
+            int diasValidade = tipoDocumentoDto.getDiasValidade() != null
+                    ? tipoDocumentoDto.getDiasValidade()
+                    : UM_MES_EN_DIAS;
+
             int qtdPeriodos = (int) Math.ceil(diasValidade);
 
             var primeiroPeriodo = gfdDocumentoDto.getDataEmissao().withDayOfMonth(1);

--- a/src/main/java/br/com/mili/milibackend/gfd/application/usecases/GfdFuncionario/GetAllGfdFuncionarioUseCaseImpl.java
+++ b/src/main/java/br/com/mili/milibackend/gfd/application/usecases/GfdFuncionario/GetAllGfdFuncionarioUseCaseImpl.java
@@ -34,7 +34,7 @@ public class GetAllGfdFuncionarioUseCaseImpl implements GetAllGfdFuncionarioUseC
                 inputDto.getPeriodoInicio(),
                 inputDto.getPeriodoFim(),
                 inputDto.getFornecedor() != null ? inputDto.getFornecedor().getCodigo() : null,
-                pageNumber,
+                pageNumber * pageSize,
                 pageSize,
                 inputDto.getAtivo() != null ? inputDto.getAtivo() : 1
         );

--- a/src/main/java/br/com/mili/milibackend/gfd/domain/entity/GfdFuncionarioTipoContratacaoEnum.java
+++ b/src/main/java/br/com/mili/milibackend/gfd/domain/entity/GfdFuncionarioTipoContratacaoEnum.java
@@ -4,7 +4,7 @@ import lombok.Getter;
 
 @Getter
 public enum GfdFuncionarioTipoContratacaoEnum {
-    SUB_CONTRATADOS("SUB_CONTRATADOS"),
+    SUBCONTRATADOS("SUBCONTRATADOS"),
     CLT("CLT"),
     CLT_SEGURANCA("CLT_SEGURANCA");
 

--- a/src/main/java/br/com/mili/milibackend/gfd/domain/entity/GfdFuncionarioTipoContratacaoEnum.java
+++ b/src/main/java/br/com/mili/milibackend/gfd/domain/entity/GfdFuncionarioTipoContratacaoEnum.java
@@ -4,7 +4,7 @@ import lombok.Getter;
 
 @Getter
 public enum GfdFuncionarioTipoContratacaoEnum {
-    PJ("PJ"),
+    SUB_CONTRATADOS("SUB_CONTRATADOS"),
     CLT("CLT"),
     CLT_SEGURANCA("CLT_SEGURANCA");
 

--- a/src/main/java/br/com/mili/milibackend/gfd/infra/repository/gfdFuncionario/GfdFuncionarioRepository.java
+++ b/src/main/java/br/com/mili/milibackend/gfd/infra/repository/gfdFuncionario/GfdFuncionarioRepository.java
@@ -38,7 +38,7 @@ public interface GfdFuncionarioRepository extends JpaRepository<GfdFuncionario, 
             FROM GFD_FORNECEDOR_FUNCIONARIO A
             JOIN GFD_TIPO_DOCUMENTO B
               ON B.TIPO = CASE
-                            WHEN A.TIPO_CONTRATACAO = 'PJ' THEN 'FUNCIONARIO_MEI'
+                            WHEN A.TIPO_CONTRATACAO = 'SUB_CONTRATADOS' THEN 'FUNCIONARIO_MEI'
                             WHEN A.TIPO_CONTRATACAO = 'CLT_SEGURANCA' THEN 'FUNCIONARIO_CLT_SEGURANCA'
                             ELSE 'FUNCIONARIO_CLT'
                          END
@@ -132,7 +132,7 @@ public interface GfdFuncionarioRepository extends JpaRepository<GfdFuncionario, 
             FROM GFD_FORNECEDOR_FUNCIONARIO A
             JOIN GFD_TIPO_DOCUMENTO B
               ON B.TIPO = CASE
-                            WHEN A.TIPO_CONTRATACAO = 'PJ' THEN 'FUNCIONARIO_MEI'
+                            WHEN A.TIPO_CONTRATACAO = 'SUB_CONTRATADOS' THEN 'FUNCIONARIO_MEI'
                             WHEN A.TIPO_CONTRATACAO = 'CLT_SEGURANCA' THEN 'FUNCIONARIO_CLT_SEGURANCA'
                             ELSE 'FUNCIONARIO_CLT'
                          END

--- a/src/main/java/br/com/mili/milibackend/gfd/infra/repository/gfdFuncionario/GfdFuncionarioRepository.java
+++ b/src/main/java/br/com/mili/milibackend/gfd/infra/repository/gfdFuncionario/GfdFuncionarioRepository.java
@@ -38,7 +38,7 @@ public interface GfdFuncionarioRepository extends JpaRepository<GfdFuncionario, 
             FROM GFD_FORNECEDOR_FUNCIONARIO A
             JOIN GFD_TIPO_DOCUMENTO B
               ON B.TIPO = CASE
-                            WHEN A.TIPO_CONTRATACAO = 'SUB_CONTRATADOS' THEN 'FUNCIONARIO_MEI'
+                            WHEN A.TIPO_CONTRATACAO = 'SUBCONTRATADOS' THEN 'FUNCIONARIO_MEI'
                             WHEN A.TIPO_CONTRATACAO = 'CLT_SEGURANCA' THEN 'FUNCIONARIO_CLT_SEGURANCA'
                             ELSE 'FUNCIONARIO_CLT'
                          END
@@ -132,7 +132,7 @@ public interface GfdFuncionarioRepository extends JpaRepository<GfdFuncionario, 
             FROM GFD_FORNECEDOR_FUNCIONARIO A
             JOIN GFD_TIPO_DOCUMENTO B
               ON B.TIPO = CASE
-                            WHEN A.TIPO_CONTRATACAO = 'SUB_CONTRATADOS' THEN 'FUNCIONARIO_MEI'
+                            WHEN A.TIPO_CONTRATACAO = 'SUBCONTRATADOS' THEN 'FUNCIONARIO_MEI'
                             WHEN A.TIPO_CONTRATACAO = 'CLT_SEGURANCA' THEN 'FUNCIONARIO_CLT_SEGURANCA'
                             ELSE 'FUNCIONARIO_CLT'
                          END


### PR DESCRIPTION
📌 Solicitação
-

**44506** – Proengel - Problemas na criação de documentos 

**44493** – Alterar no campo contratação o valor PJ para SubContratados

 ✅ Solução
-

**44506** 
- Correção na criação do período, onde a criação estava tendo problema ao ver que não tinha dias de validade no tipo documento, ocorrendo null point. O valor 10 anos foi setado caso o valor seja null

**44493** 
- Alterado SQL, consultas e enums para SubContratados
