### PR TITLE
feat: 45641 block users who haven't accepted LGPD from viewing, creating or updating documents and employees

### DIFF
--- a/src/main/java/br/com/mili/milibackend/gfd/adapter/exception/GfdMCodeException.java
+++ b/src/main/java/br/com/mili/milibackend/gfd/adapter/exception/GfdMCodeException.java
@@ -8,6 +8,7 @@ import lombok.Getter;
 public enum GfdMCodeException {
     GFD_DOCUMENTO_NAO_ENCONTRADO("GFD_DOCUMENTO_NAO_ENCONTRADO", "O documento não foi encontrado"),
     GFD_FORNECEDOR_NAO_ENCONTRADO("GFD_FORNECEDOR_NAO_ENCONTRADO", "Fornecedor não encontrado"),
+    GFD_LEI_LGPD_NAO_ACEITA("GFD_LEI_LGPD_NAO_ACEITA", "Identificamos que você ainda não aceitou os termos da LGPD. Por favor, acesse Meus Dados e aceite os termos para continuar."),
     GFD_TIPO_DOCUMENTO_FUNCIONARIO_BAD_REQUEST("GFD_TIPO_DOCUMENTO_FUNCIONARIO_BAD_REQUEST", "Tipo de documento não pode ser de fornecedor, quando enviar o funcionário id"),
     GFD_TIPO_DOCUMENTO_NAO_ENCONTRADO("GFD_TIPO_DOCUMENTO__NAO_ENCONTRADO", "Tipo de documento não encontrado"),
     GFD_CATEGORIA_DOCUMENTO_NAO_ENCONTRADO("GFD_CATEGORIA_DOCUMENTO_NAO_ENCONTRADO", "Categoria de documento não encontrado"),

--- a/src/main/java/br/com/mili/milibackend/gfd/application/usecases/GfdDocumento/GetAllStatusGfdDocumentsUseCaseImpl.java
+++ b/src/main/java/br/com/mili/milibackend/gfd/application/usecases/GfdDocumento/GetAllStatusGfdDocumentsUseCaseImpl.java
@@ -13,6 +13,7 @@ import br.com.mili.milibackend.gfd.domain.usecases.GetAllGfdDocumentsStatusUseCa
 import br.com.mili.milibackend.gfd.domain.usecases.GetAllTipoDocumentoUseCase;
 import br.com.mili.milibackend.gfd.infra.repository.gfdDocumento.GfdDocumentoRepository;
 import br.com.mili.milibackend.gfd.infra.repository.gfdFuncionario.GfdFuncionarioRepository;
+import br.com.mili.milibackend.shared.exception.types.ConflictException;
 import br.com.mili.milibackend.shared.exception.types.NotFoundException;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -23,6 +24,7 @@ import java.util.List;
 import java.util.Set;
 
 import static br.com.mili.milibackend.gfd.adapter.exception.GfdFuncionarioCodeException.GFD_FUNCIONARIO_NAO_ENCONTRADO;
+import static br.com.mili.milibackend.gfd.adapter.exception.GfdMCodeException.GFD_LEI_LGPD_NAO_ACEITA;
 
 @RequiredArgsConstructor
 @Service
@@ -38,6 +40,10 @@ public class GetAllStatusGfdDocumentsUseCaseImpl implements GetAllGfdDocumentsSt
         var documentos = new LinkedHashSet<GfdMVerificarDocumentosOutputDto.DocumentoDto>();
 
         var fornecedor = getFornecedorByCodOrIdUseCase.execute(inputDto.getCodUsuario(), inputDto.getId());
+
+       if(fornecedor.getAceiteLgpd() == null || fornecedor.getAceiteLgpd() == 0){
+            throw new ConflictException(GFD_LEI_LGPD_NAO_ACEITA.getMensagem(), GFD_LEI_LGPD_NAO_ACEITA.getCode());
+        }
 
         // adiciona no title o nome do fornecedor
         output.setTitle(fornecedor.getRazaoSocial());

--- a/src/main/java/br/com/mili/milibackend/gfd/application/usecases/GfdDocumento/GetAllSupplierDocumentsUseCaseImpl.java
+++ b/src/main/java/br/com/mili/milibackend/gfd/application/usecases/GfdDocumento/GetAllSupplierDocumentsUseCaseImpl.java
@@ -17,6 +17,7 @@ import br.com.mili.milibackend.gfd.domain.usecases.GetAllTipoDocumentoUseCase;
 import br.com.mili.milibackend.gfd.infra.repository.GfdDocumentoPeriodoRepository;
 import br.com.mili.milibackend.gfd.infra.repository.GfdTipoDocumentoRepository;
 import br.com.mili.milibackend.gfd.infra.repository.gfdFuncionario.GfdFuncionarioRepository;
+import br.com.mili.milibackend.shared.exception.types.ConflictException;
 import br.com.mili.milibackend.shared.exception.types.NotFoundException;
 import br.com.mili.milibackend.shared.page.pagination.PageBaseImpl;
 import br.com.mili.milibackend.shared.util.CleanFileName;
@@ -27,6 +28,7 @@ import org.springframework.stereotype.Service;
 import java.util.List;
 
 import static br.com.mili.milibackend.gfd.adapter.exception.GfdFuncionarioCodeException.GFD_FUNCIONARIO_NAO_ENCONTRADO;
+import static br.com.mili.milibackend.gfd.adapter.exception.GfdMCodeException.GFD_LEI_LGPD_NAO_ACEITA;
 import static br.com.mili.milibackend.gfd.adapter.exception.GfdMCodeException.GFD_TIPO_DOCUMENTO_NAO_ENCONTRADO;
 
 @Service
@@ -44,6 +46,10 @@ public class GetAllSupplierDocumentsUseCaseImpl implements GetAllSupplierDocumen
     @Override
     public GfdMDocumentosGetAllOutputDto execute(GfdMDocumentosGetAllInputDto inputDto) {
         var fornecedor = getFornecedorByCodOrIdUseCase.execute(inputDto.getCodUsuario(), inputDto.getId());
+
+       if(fornecedor.getAceiteLgpd() == null || fornecedor.getAceiteLgpd() == 0){
+            throw new ConflictException(GFD_LEI_LGPD_NAO_ACEITA.getMensagem(), GFD_LEI_LGPD_NAO_ACEITA.getCode());
+        }
 
         var tipoDocumento = recuperarTipoDocumento(inputDto);
 

--- a/src/main/java/br/com/mili/milibackend/gfd/application/usecases/GfdDocumento/UploadGfdDocumentoUseCaseImpl.java
+++ b/src/main/java/br/com/mili/milibackend/gfd/application/usecases/GfdDocumento/UploadGfdDocumentoUseCaseImpl.java
@@ -18,6 +18,7 @@ import br.com.mili.milibackend.gfd.domain.usecases.UploadGfdDocumentoUseCase;
 import br.com.mili.milibackend.gfd.infra.repository.GfdTipoDocumentoRepository;
 import br.com.mili.milibackend.shared.enums.MimeTypeEnum;
 import br.com.mili.milibackend.shared.exception.types.BadRequestException;
+import br.com.mili.milibackend.shared.exception.types.ConflictException;
 import br.com.mili.milibackend.shared.exception.types.NotFoundException;
 import br.com.mili.milibackend.shared.infra.aws.IS3Service;
 import br.com.mili.milibackend.shared.infra.aws.StorageFolderEnum;
@@ -29,8 +30,7 @@ import org.springframework.stereotype.Service;
 
 import java.time.LocalDate;
 
-import static br.com.mili.milibackend.gfd.adapter.exception.GfdMCodeException.GFD_FORNECEDOR_NAO_ENCONTRADO;
-import static br.com.mili.milibackend.gfd.adapter.exception.GfdMCodeException.GFD_TIPO_DOCUMENTO_FUNCIONARIO_BAD_REQUEST;
+import static br.com.mili.milibackend.gfd.adapter.exception.GfdMCodeException.*;
 
 @Service
 @RequiredArgsConstructor
@@ -52,6 +52,10 @@ public class UploadGfdDocumentoUseCaseImpl implements UploadGfdDocumentoUseCase 
         var base64FileName = gfdDocumentoDto.getBase64File().fileName();
 
         var fornecedor = getFornecedorByCodOrIdUseCase.execute(inputDto.getCodUsuario(), inputDto.getId());
+
+       if(fornecedor.getAceiteLgpd() == null || fornecedor.getAceiteLgpd() == 0){
+            throw new ConflictException(GFD_LEI_LGPD_NAO_ACEITA.getMensagem(), GFD_LEI_LGPD_NAO_ACEITA.getCode());
+        }
 
         var tipoDocumento = recuperarTipoDocumento(inputDto);
 


### PR DESCRIPTION

📌 Solicitação
-

**45641** – As empresas estão conseguindo criar documentos mesmo sem aceitar a LGPD


 ✅ Solução
-

**45641** 
- Adicionado restrição que não permite o usuario visualizar, criar, atualizar, deletar documentos e funcionários
- Foi reorganizado getFornecedorAndValidate, pois os métodos que estavam usando-o, estavam colocando os argumentos na ordem errada.

