### PR TITLE
fix: 45641 validatePermissionFornecedorUseCase with arg codfornecedor is null

### DIFF
--- a/src/main/java/br/com/mili/milibackend/gfd/application/service/GfdManagerService.java
+++ b/src/main/java/br/com/mili/milibackend/gfd/application/service/GfdManagerService.java
@@ -136,7 +136,7 @@ public class GfdManagerService implements IGfdManagerService {
         var fornecedor = getFornecedorByCodOrIdUseCase.execute(codUsuario, idFornecedor);
 
         //todo: colocar no dto isAnalista pare evitar isso
-        if (!validatePermissionFornecedorUseCase.execute(codUsuario, idFornecedor)) {
+        if (!validatePermissionFornecedorUseCase.execute(codUsuario, fornecedor.getCodigo())) {
             throw new ForbiddenException(GFD_FUNCIONARIO_SEM_PERMISSAO.getMensagem(), GFD_FUNCIONARIO_SEM_PERMISSAO.getCode());
         }
 


### PR DESCRIPTION
📌 Solicitação
-

**45641** – As empresas estão conseguindo criar documentos mesmo sem aceitar a LGPD


 ✅ Solução
-

**45641** 
- corrigido validatePermissionFornecedorUseCase  com argumento de codfornecedor null

